### PR TITLE
Updated parse to check if title is present or not.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,12 @@ function parse(stdout) {
 	if (process.platform === 'darwin') {
 		const parts = stdout.trim().split('\n');
 
+		// First part isn't always the title.
+		// Check if first character was newline.
+		if(stdout.indexOf('\n') === 0) {
+			parts.unshift(parts[1]);
+		}
+
 		return {
 			title: parts[0] || null,
 			id: Number(parts[1]),


### PR DESCRIPTION
Some apps, such as Chrome and Spotify don't seem to have a title at times (or at all) on OS X. In cases like these the first character of stdout is a newline character. Checking if the first character is a newline will reveal the lack of title, so the title is set to the app name.