### PR TITLE
Add Windows support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,17 @@ language: node_js
 node_js:
   - '6'
   - '4'
-env: DISPLAY=:99.0
+env:
+  - DISPLAY=:99.0
+  - CXX=g++-4.8
 install: true
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
     - metacity
+    - g++-4.8
 before_script:
   - "if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sh -e /etc/init.d/xvfb start; fi"
   - "if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sleep 3; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,12 @@ language: node_js
 node_js:
   - '6'
   - '4'
-env:
-  global:
-    - DISPLAY=:99.0
-    - CXX=g++-4.8
+env: DISPLAY=:99.0
 install: true
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
     - metacity
-    - g++-4.8
 before_script:
   - "if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sh -e /etc/init.d/xvfb start; fi"
   - "if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sleep 3; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ node_js:
   - '6'
   - '4'
 env:
-  - DISPLAY=:99.0
-  - CXX=g++-4.8
+  global:
+    - DISPLAY=:99.0
+    - CXX=g++-4.8
 install: true
 addons:
   apt:
@@ -23,4 +24,3 @@ before_script:
 script:
   - npm install
   - npm test
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ before_script:
 script:
   - npm install
   - npm test
+

--- a/index.js
+++ b/index.js
@@ -28,10 +28,13 @@ function parse(stdout) {
 				result[parts[0].trim()] = parts[1].trim();
 			}
 		}
+		const windowIdProperty = 'WM_CLIENT_LEADER(WINDOW)';
+		const windowId = (result.hasOwnProperty(windowIdProperty) &&
+			parseInt(result[windowIdProperty].split('#').pop(), 16)) || null
 
 		return {
 			title: JSON.parse(result['_NET_WM_NAME(UTF8_STRING)']) || null,
-			id: parseInt(result['WM_CLIENT_LEADER(WINDOW)'].split('#').pop(), 16),
+			id: windowId,
 			app: JSON.parse(result['WM_CLASS(STRING)'].split(',').pop()),
 			pid: parseInt(result['_NET_WM_PID(CARDINAL)'], 10)
 		};

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ const parseLinux = linuxData => {
 	};
 };
 
-const getActiveWindowId = activeWindowIdStdout => activeWindowIdStdout.split('\t')[1].replace('\'', '').trim();
+const getActiveWindowId = activeWindowIdStdout => parseInt(activeWindowIdStdout.split('\t')[1].replace('\'', '').trim(), 16);
 
 module.exports = () => {
 	if (process.platform === 'darwin') {

--- a/index.js
+++ b/index.js
@@ -29,8 +29,9 @@ function parse(stdout) {
 			}
 		}
 		const windowIdProperty = 'WM_CLIENT_LEADER(WINDOW)';
-		const windowId = (result.hasOwnProperty(windowIdProperty) &&
-			parseInt(result[windowIdProperty].split('#').pop(), 16)) || null
+		const resultKeys = Object.keys(result);
+		const windowId = (resultKeys.indexOf(windowIdProperty) > 0 &&
+			parseInt(result[windowIdProperty].split('#').pop(), 16)) || null;
 
 		return {
 			title: JSON.parse(result['_NET_WM_NAME(UTF8_STRING)']) || null,

--- a/index.js
+++ b/index.js
@@ -64,8 +64,11 @@ module.exports = () => {
 				});
 			}
 		).then(parseLinux);
+	} else if (process.platform === 'win32') {
+		const windows = require('./windows');
+		return Promise.resolve(windows());
 	}
-	return Promise.reject(new Error('macOS and Linux only'));
+	return Promise.reject(new Error('macOS, Linux and Windows only'));
 };
 
 module.exports.sync = () => {
@@ -79,7 +82,10 @@ module.exports.sync = () => {
 			activeWindowId,
 			stdout
 		});
+	} else if (process.platform === 'win32') {
+		const windows = require('./windows');
+		return windows();
 	}
 
-	throw new Error('macOS and Linux only');
+	throw new Error('macOS, Linux and Windows only');
 };

--- a/index.js
+++ b/index.js
@@ -4,61 +4,78 @@ const childProcess = require('child_process');
 const pify = require('pify');
 
 const bin = path.join(__dirname, 'main');
-const xprop = 'xprop -id $(xprop -root 32x \'\\t$0\' _NET_ACTIVE_WINDOW | cut -f 2)';
+const xpropActive = 'xprop -root 32x \'\\t$0\' _NET_ACTIVE_WINDOW | cut -f 2';
+const xpropDetails = 'xprop -id';
 
-function parse(stdout) {
-	if (process.platform === 'darwin') {
-		const parts = stdout.trimRight().split('\n');
+const parseMac = stdout => {
+	const parts = stdout.trimRight().split('\n');
 
-		return {
-			title: parts[0],
-			id: Number(parts[1]),
-			app: parts[2],
-			pid: Number(parts[3])
-		};
-	} else if (process.platform === 'linux') {
-		const result = {};
+	return {
+		title: parts[0],
+		id: Number(parts[1]),
+		app: parts[2],
+		pid: Number(parts[3])
+	};
+};
 
-		for (const row of stdout.trim().split('\n')) {
-			if (row.includes('=')) {
-				const parts = row.split('=');
-				result[parts[0].trim()] = parts[1].trim();
-			} else if (row.includes(':')) {
-				const parts = row.split(':');
-				result[parts[0].trim()] = parts[1].trim();
-			}
+const parseLinux = linuxData => {
+	const stdout = linuxData.stdout;
+	const activeWindowId = linuxData.activeWindowId;
+
+	const result = {};
+	for (const row of stdout.trim().split('\n')) {
+		if (row.includes('=')) {
+			const parts = row.split('=');
+			result[parts[0].trim()] = parts[1].trim();
+		} else if (row.includes(':')) {
+			const parts = row.split(':');
+			result[parts[0].trim()] = parts[1].trim();
 		}
-		const windowIdProperty = 'WM_CLIENT_LEADER(WINDOW)';
-		const resultKeys = Object.keys(result);
-		const windowId = (resultKeys.indexOf(windowIdProperty) > 0 &&
-			parseInt(result[windowIdProperty].split('#').pop(), 16)) || null;
-
-		return {
-			title: JSON.parse(result['_NET_WM_NAME(UTF8_STRING)']) || null,
-			id: windowId,
-			app: JSON.parse(result['WM_CLASS(STRING)'].split(',').pop()),
-			pid: parseInt(result['_NET_WM_PID(CARDINAL)'], 10)
-		};
 	}
 
-	throw new Error('macOS and Linux only');
-}
+	const windowIdProperty = 'WM_CLIENT_LEADER(WINDOW)';
+	const resultKeys = Object.keys(result);
+	const windowId = (resultKeys.indexOf(windowIdProperty) > 0 &&
+		parseInt(result[windowIdProperty].split('#').pop(), 16)) || activeWindowId;
+
+	return {
+		title: JSON.parse(result['_NET_WM_NAME(UTF8_STRING)']) || null,
+		id: windowId,
+		app: JSON.parse(result['WM_CLASS(STRING)'].split(',').pop()),
+		pid: parseInt(result['_NET_WM_PID(CARDINAL)'], 10)
+	};
+};
 
 module.exports = () => {
 	if (process.platform === 'darwin') {
-		return pify(childProcess.execFile)(bin).then(parse);
+		return pify(childProcess.execFile)(bin).then(parseMac);
 	} else if (process.platform === 'linux') {
-		return pify(childProcess.exec)(xprop).then(parse);
+		return pify(childProcess.exec)(xpropActive).then(
+			activeWindowIdStdout => {
+				const activeWindowId = activeWindowIdStdout.trim();
+				return pify(childProcess.exec)(`${xpropDetails} ${activeWindowId}`).then(stdout => {
+					return {
+						activeWindowId,
+						stdout
+					};
+				});
+			}
+		).then(parseLinux);
 	}
-
 	return Promise.reject(new Error('macOS and Linux only'));
 };
 
 module.exports.sync = () => {
 	if (process.platform === 'darwin') {
-		return parse(childProcess.execFileSync(bin, {encoding: 'utf8'}));
+		return parseMac(childProcess.execFileSync(bin, {encoding: 'utf8'}));
 	} else if (process.platform === 'linux') {
-		return parse(childProcess.execSync(xprop, {encoding: 'utf8'}));
+		const activeWindowIdStdout = childProcess.execSync(xpropActive, {encoding: 'utf8'});
+		const activeWindowId = activeWindowIdStdout.trim();
+		const stdout = childProcess.execSync(`${xpropDetails} ${activeWindowId}`, {encoding: 'utf8'});
+		return parseLinux({
+			activeWindowId,
+			stdout
+		});
 	}
 
 	throw new Error('macOS and Linux only');

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "xo": "*"
   },
   "optionalDependencies": {
-    "ffi": "^2.2.0",
-    "ref": "^1.3.4",
+    "fastcall": "^0.2.4",
     "ref-wchar": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,13 +39,15 @@
     "capture"
   ],
   "dependencies": {
-    "ffi": "^2.2.0",
-    "pify": "^2.3.0",
-    "ref": "^1.3.4",
-    "ref-wchar": "^1.0.2"
+    "pify": "^2.3.0"
   },
   "devDependencies": {
     "ava": "*",
     "xo": "*"
+  },
+  "optionalDependencies": {
+    "ffi": "^2.2.0",
+    "ref": "^1.3.4",
+    "ref-wchar": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "files": [
     "index.js",
+    "windows.js",
     "main"
   ],
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "active-win",
   "version": "1.0.1",
-  "description": "Get the title/id/etc of the active window (macOS & Linux)",
+  "description": "Get the title / window id / app name / process ID of the active window (macOS, Linux & Windows)",
   "license": "MIT",
   "repository": "sindresorhus/active-win",
   "author": {
@@ -24,6 +24,7 @@
     "macos",
     "osx",
     "linux",
+    "windows",
     "app",
     "application",
     "window",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,10 @@
     "capture"
   ],
   "dependencies": {
-    "pify": "^2.3.0"
+    "ffi": "^2.2.0",
+    "pify": "^2.3.0",
+    "ref": "^1.3.4",
+    "ref-wchar": "^1.0.2"
   },
   "devDependencies": {
     "ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,6 @@
 # active-win [![Build Status](https://travis-ci.org/sindresorhus/active-win.svg?branch=master)](https://travis-ci.org/sindresorhus/active-win)
 
-> Get the title/id/etc of the [active window](https://en.wikipedia.org/wiki/Active_window) *(macOS & Linux)*
-
-*PR welcome for Windows support.*
+Get the title / window id / app name / process ID of the [active window](https://en.wikipedia.org/wiki/Active_window) *(macOS, Linux and Windows)*
 
 
 ## Install
@@ -45,9 +43,16 @@ Returns the result `Object`.
 ## Result
 
 - `title` - Window title
-- `id` - Window ID
+- `id` - Window ID (in MacOS and Linux)
 - `app` - App owning the window
 - `pid` - Process ID of the app owning the window
+
+
+## Operating system support
+
+It works with MacOS, Linux and Windows (tested in Windows 7 and above).
+
+**Note**: In Windows, there's no notion of a "Window ID". So, when used in Windows, it returns `-1` in the `id` property of the object.
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ Returns the result `Object`.
 ## Result
 
 - `title` - Window title
-- `id` - Window ID (in MacOS and Linux)
+- `id` - Window ID (in macOS and Linux)
 - `app` - App owning the window
 - `pid` - Process ID of the app owning the window
 

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ Returns the result `Object`.
 
 ## Operating system support
 
-It works with MacOS, Linux and Windows (tested in Windows 7 and above).
+It works with macOS, Linux and Windows 7+.
 
 **Note**: In Windows, there's no notion of a "Window ID". So, when used in Windows, it returns `-1` in the `id` property of the object.
 

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ Returns the result `Object`.
 
 It works with macOS, Linux and Windows 7+.
 
-**Note**: In Windows, there's no notion of a "Window ID". So, when used in Windows, it returns `-1` in the `id` property of the object.
+**Note**: In Windows, there isn't a clear notion of a "Window ID". So, when used in Windows, it returns the memory address of the window "handle" in the `id` property of the object, that "handle" is unique per window, so it can be used to identify them. To learn more about it refer to the [official Windows documentation](https://msdn.microsoft.com/en-us/library/windows/desktop/ms632597(v=vs.85).aspx#window_handle).
 
 
 ## Related

--- a/windows.js
+++ b/windows.js
@@ -1,0 +1,70 @@
+'use strict';
+const path = require('path');
+
+const ffi = require('ffi');
+const ref = require('ref');
+const wchar_t = require('ref-wchar');
+
+// Required by QueryFullProcessImageName
+// https://msdn.microsoft.com/en-us/library/windows/desktop/ms684880(v=vs.85).aspx
+const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+
+// ffi declarations for the C++ library and functions needed (User32.dll), using their "Unicode" (UTF-16) version
+const user32 = ffi.Library('user32', {
+	'GetForegroundWindow': ['pointer', []],
+	'GetWindowTextW': ['int', ['pointer', 'pointer', 'int']],
+	'GetWindowTextLengthW': ['int', ['pointer']],
+	'GetWindowThreadProcessId': ['uint32', ['pointer', 'uint32 *']],
+});
+
+// ffi declarations for the C++ library and functions needed (Kernel32.dll), using their "Unicode" (UTF-16) version
+const kernel32 = ffi.Library('kernel32', {
+	'OpenProcess': ['pointer', ['uint32', 'int', 'uint32']],
+	'CloseHandle': ['int', ['pointer']],
+	'QueryFullProcessImageNameW': ['int', ['pointer', 'uint32', 'pointer', 'pointer']],
+});
+
+module.exports = () => {
+	// Get a "handle" of the active window
+	const activeWindowHandle = user32.GetForegroundWindow();
+	// Get the window text length in "characters", to create the buffer
+	const windowTextLength = user32.GetWindowTextLengthW(activeWindowHandle);
+	// Allocate a buffer large enough to hold the window text as "Unicode" (UTF-16) characters (using ref-wchar)
+	// This assumes using the "Basic Multilingual Plane" of Unicode, only 2 characters per Unicode code point
+	// Include some extra bytes for possible null characters
+	const windowTextBuffer = Buffer.alloc(windowTextLength * 2 + 4);
+	// Write the window text to the buffer
+	const windowTextSize = user32.GetWindowTextW(activeWindowHandle, windowTextBuffer, windowTextLength + 2);
+	// Remove trailing null characters
+	const windowTextBufferClean = ref.reinterpretUntilZeros(windowTextBuffer, wchar_t.size)
+	// The the text as a Javascript string
+	const windowTitle = wchar_t.toString(windowTextBufferClean);
+
+	// Allocate a buffer to store the process ID
+	const processIdBuffer = ref.alloc('uint32');
+	// Write the process ID creating the window to the buffer
+	const threadId = user32.GetWindowThreadProcessId(activeWindowHandle, processIdBuffer);
+	// get the process ID as a number from the buffer
+	const processId = ref.get(processIdBuffer);
+	// Get a "handle" of the process
+	let processHandle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, processId);
+	// Set the path length to more than the Windows extended-length MAX_PATH length
+	const pathLengthBytes = 66000;
+	// Path length in "characters"
+	const pathLengthChars = Math.floor(pathLengthBytes / 2);
+	// Allocate a buffer to store the path of the process
+	const processFileNameBuffer = Buffer.alloc(pathLengthBytes);
+	// Create a buffer contain
+	const processFileNameSizeBuffer = ref.alloc('uint32', pathLengthChars);
+	kernel32.QueryFullProcessImageNameW(processHandle, 0, processFileNameBuffer, processFileNameSizeBuffer);
+	const processFileNameBufferClean = ref.reinterpretUntilZeros(processFileNameBuffer, wchar_t.size);
+	const processPath = wchar_t.toString(processFileNameBufferClean);
+	const processName = path.basename(processPath);
+
+	return {
+		title: windowTitle,
+		id: 0,
+		app: processName,
+		pid: processId,
+	};
+}

--- a/windows.js
+++ b/windows.js
@@ -32,6 +32,9 @@ const kernel32 = new ffi.Library('kernel32', {
 });
 
 module.exports = () => {
+	// Windows C++ APIs' functions are declared with capitals, so this rule has to be turned off.
+	/* eslint new-cap: off */
+
 	// Get a "handle" of the active window
 	const activeWindowHandle = user32.GetForegroundWindow();
 	// Get the window text length in "characters", to create the buffer

--- a/windows.js
+++ b/windows.js
@@ -24,9 +24,7 @@ const user32 = new fastcall.Library('User32.dll')
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633521(v=vs.85).aspx
 	.function({GetWindowTextLengthW: ['int', ['pointer']]})
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633522(v=vs.85).aspx
-	.function({GetWindowThreadProcessId: ['uint32', ['pointer', 'uint32 *']]})
-	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633584(v=vs.85).aspx
-	.function({GetWindowLongW: ['long', ['pointer', 'int']]});
+	.function({GetWindowThreadProcessId: ['uint32', ['pointer', 'uint32 *']]});
 
 // Create ffi declarations for the C++ library and functions needed (Kernel32.dll), using their "Unicode" (UTF-16) version
 const kernel32 = new fastcall.Library('kernel32')
@@ -43,8 +41,8 @@ module.exports = () => {
 
 	// Get a "handle" of the active window
 	const activeWindowHandle = user32.interface.GetForegroundWindow();
-	// Get the Window ID, as GWL_ID
-	const windowId = user32.interface.GetWindowLongW(activeWindowHandle, GWL_ID);
+	// Get memory address of the window handle as the "window ID"
+	const windowId = ref.address(activeWindowHandle);
 	// Get the window text length in "characters", to create the buffer
 	const windowTextLength = user32.interface.GetWindowTextLengthW(activeWindowHandle);
 	// Allocate a buffer large enough to hold the window text as "Unicode" (UTF-16) characters (using ref-wchar)
@@ -87,7 +85,6 @@ module.exports = () => {
 
 	return {
 		title: windowTitle,
-		// There doesn't seem to be a notion of "window ID" in Windows, so returning -1
 		id: windowId,
 		app: processName,
 		pid: processId

--- a/windows.js
+++ b/windows.js
@@ -3,32 +3,32 @@ const path = require('path');
 
 const ffi = require('ffi');
 const ref = require('ref');
-const wchar_t = require('ref-wchar');
+const wchar = require('ref-wchar');
 
 // Required by QueryFullProcessImageName
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms684880(v=vs.85).aspx
 const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
 
-// ffi declarations for the C++ library and functions needed (User32.dll), using their "Unicode" (UTF-16) version
-const user32 = ffi.Library('user32', {
+// Create ffi declarations for the C++ library and functions needed (User32.dll), using their "Unicode" (UTF-16) version
+const user32 = new ffi.Library('user32', {
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633505(v=vs.85).aspx
-	'GetForegroundWindow': ['pointer', []],
+	GetForegroundWindow: ['pointer', []],
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633520(v=vs.85).aspx
-	'GetWindowTextW': ['int', ['pointer', 'pointer', 'int']],
+	GetWindowTextW: ['int', ['pointer', 'pointer', 'int']],
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633521(v=vs.85).aspx
-	'GetWindowTextLengthW': ['int', ['pointer']],
+	GetWindowTextLengthW: ['int', ['pointer']],
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633522(v=vs.85).aspx
-	'GetWindowThreadProcessId': ['uint32', ['pointer', 'uint32 *']],
+	GetWindowThreadProcessId: ['uint32', ['pointer', 'uint32 *']]
 });
 
-// ffi declarations for the C++ library and functions needed (Kernel32.dll), using their "Unicode" (UTF-16) version
-const kernel32 = ffi.Library('kernel32', {
+// Create ffi declarations for the C++ library and functions needed (Kernel32.dll), using their "Unicode" (UTF-16) version
+const kernel32 = new ffi.Library('kernel32', {
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms684320(v=vs.85).aspx
-	'OpenProcess': ['pointer', ['uint32', 'int', 'uint32']],
+	OpenProcess: ['pointer', ['uint32', 'int', 'uint32']],
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms724211(v=vs.85).aspx
-	'CloseHandle': ['int', ['pointer']],
+	CloseHandle: ['int', ['pointer']],
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms684919(v=vs.85).aspx
-	'QueryFullProcessImageNameW': ['int', ['pointer', 'uint32', 'pointer', 'pointer']],
+	QueryFullProcessImageNameW: ['int', ['pointer', 'uint32', 'pointer', 'pointer']]
 });
 
 module.exports = () => {
@@ -39,22 +39,22 @@ module.exports = () => {
 	// Allocate a buffer large enough to hold the window text as "Unicode" (UTF-16) characters (using ref-wchar)
 	// This assumes using the "Basic Multilingual Plane" of Unicode, only 2 characters per Unicode code point
 	// Include some extra bytes for possible null characters
-	const windowTextBuffer = Buffer.alloc(windowTextLength * 2 + 4);
-	// Write the window text to the buffer
-	const windowTextSize = user32.GetWindowTextW(activeWindowHandle, windowTextBuffer, windowTextLength + 2);
+	const windowTextBuffer = Buffer.alloc((windowTextLength * 2) + 4);
+	// Write the window text to the buffer (it returns the text size, but is not used here)
+	user32.GetWindowTextW(activeWindowHandle, windowTextBuffer, windowTextLength + 2);
 	// Remove trailing null characters
-	const windowTextBufferClean = ref.reinterpretUntilZeros(windowTextBuffer, wchar_t.size)
+	const windowTextBufferClean = ref.reinterpretUntilZeros(windowTextBuffer, wchar.size);
 	// The the text as a Javascript string
-	const windowTitle = wchar_t.toString(windowTextBufferClean);
+	const windowTitle = wchar.toString(windowTextBufferClean);
 
 	// Allocate a buffer to store the process ID
 	const processIdBuffer = ref.alloc('uint32');
-	// Write the process ID creating the window to the buffer
-	const threadId = user32.GetWindowThreadProcessId(activeWindowHandle, processIdBuffer);
-	// get the process ID as a number from the buffer
+	// Write the process ID creating the window to the buffer (it returns the thread ID, but is not used here)
+	user32.GetWindowThreadProcessId(activeWindowHandle, processIdBuffer);
+	// Get the process ID as a number from the buffer
 	const processId = ref.get(processIdBuffer);
 	// Get a "handle" of the process
-	let processHandle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, processId);
+	const processHandle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, processId);
 	// Set the path length to more than the Windows extended-length MAX_PATH length
 	const pathLengthBytes = 66000;
 	// Path length in "characters"
@@ -66,9 +66,9 @@ module.exports = () => {
 	// Write process file path to buffer
 	kernel32.QueryFullProcessImageNameW(processHandle, 0, processFileNameBuffer, processFileNameSizeBuffer);
 	// Remove null characters from buffer
-	const processFileNameBufferClean = ref.reinterpretUntilZeros(processFileNameBuffer, wchar_t.size);
+	const processFileNameBufferClean = ref.reinterpretUntilZeros(processFileNameBuffer, wchar.size);
 	// Get process file path as a string
-	const processPath = wchar_t.toString(processFileNameBufferClean);
+	const processPath = wchar.toString(processFileNameBufferClean);
 	// Get process file name from path
 	const processName = path.basename(processPath);
 	// Close the "handle" of the process
@@ -79,6 +79,6 @@ module.exports = () => {
 		// There doesn't seem to be a notion of "window ID" in Windows, so returning -1
 		id: -1,
 		app: processName,
-		pid: processId,
+		pid: processId
 	};
-}
+};

--- a/windows.js
+++ b/windows.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unresolved */
 'use strict';
 const path = require('path');
 

--- a/windows.js
+++ b/windows.js
@@ -2,8 +2,9 @@
 const path = require('path');
 
 const fastcall = require('fastcall');
-const ref = fastcall.ref;
 const wchar = require('ref-wchar');
+
+const ref = fastcall.ref;
 
 // Required by QueryFullProcessImageName
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms684880(v=vs.85).aspx
@@ -14,8 +15,7 @@ const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
 const GWL_ID = -12;
 
 // Create ffi declarations for the C++ library and functions needed (User32.dll), using their "Unicode" (UTF-16) version
-let user32;
-user32 = (new fastcall.Library('User32.dll')
+const user32 = new fastcall.Library('User32.dll')
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633505(v=vs.85).aspx
 	.function({GetForegroundWindow: ['pointer', []]})
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633520(v=vs.85).aspx
@@ -25,23 +25,20 @@ user32 = (new fastcall.Library('User32.dll')
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633522(v=vs.85).aspx
 	.function({GetWindowThreadProcessId: ['uint32', ['pointer', 'uint32 *']]})
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633584(v=vs.85).aspx
-	.function({GetWindowLongW: ['long', ['pointer', 'int']]})
-	);
-
+	.function({GetWindowLongW: ['long', ['pointer', 'int']]});
 
 // Create ffi declarations for the C++ library and functions needed (Kernel32.dll), using their "Unicode" (UTF-16) version
-let kernel32;
-kernel32 = (new fastcall.Library('kernel32')
+const kernel32 = new fastcall.Library('kernel32')
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms684320(v=vs.85).aspx
 	.function({OpenProcess: ['pointer', ['uint32', 'int', 'uint32']]})
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms724211(v=vs.85).aspx
 	.function({CloseHandle: ['int', ['pointer']]})
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms684919(v=vs.85).aspx
-	.function({QueryFullProcessImageNameW: ['int', ['pointer', 'uint32', 'pointer', 'pointer']]}));
+	.function({QueryFullProcessImageNameW: ['int', ['pointer', 'uint32', 'pointer', 'pointer']]});
 
 module.exports = () => {
 	// Windows C++ APIs' functions are declared with capitals, so this rule has to be turned off.
-	/* eslint new-cap: off */
+	/* eslint-disable new-cap */
 
 	// Get a "handle" of the active window
 	const activeWindowHandle = user32.interface.GetForegroundWindow();
@@ -57,7 +54,7 @@ module.exports = () => {
 	user32.interface.GetWindowTextW(activeWindowHandle, windowTextBuffer, windowTextLength + 2);
 	// Remove trailing null characters
 	const windowTextBufferClean = ref.reinterpretUntilZeros(windowTextBuffer, wchar.size);
-	// The the text as a Javascript string
+	// The text as a JavaScript string
 	const windowTitle = wchar.toString(windowTextBufferClean);
 
 	// Allocate a buffer to store the process ID

--- a/windows.js
+++ b/windows.js
@@ -1,50 +1,60 @@
 'use strict';
 const path = require('path');
 
-const ffi = require('ffi');
-const ref = require('ref');
+const fastcall = require('fastcall');
+const ref = fastcall.ref;
 const wchar = require('ref-wchar');
 
 // Required by QueryFullProcessImageName
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms684880(v=vs.85).aspx
 const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
 
+// Used by GetWindowLong
+// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633584(v=vs.85).aspx
+const GWL_ID = -12;
+
 // Create ffi declarations for the C++ library and functions needed (User32.dll), using their "Unicode" (UTF-16) version
-const user32 = new ffi.Library('user32', {
+let user32;
+user32 = (new fastcall.Library('User32.dll')
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633505(v=vs.85).aspx
-	GetForegroundWindow: ['pointer', []],
+	.function({GetForegroundWindow: ['pointer', []]})
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633520(v=vs.85).aspx
-	GetWindowTextW: ['int', ['pointer', 'pointer', 'int']],
+	.function({GetWindowTextW: ['int', ['pointer', 'pointer', 'int']]})
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633521(v=vs.85).aspx
-	GetWindowTextLengthW: ['int', ['pointer']],
+	.function({GetWindowTextLengthW: ['int', ['pointer']]})
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633522(v=vs.85).aspx
-	GetWindowThreadProcessId: ['uint32', ['pointer', 'uint32 *']]
-});
+	.function({GetWindowThreadProcessId: ['uint32', ['pointer', 'uint32 *']]})
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633584(v=vs.85).aspx
+	.function({GetWindowLongW: ['long', ['pointer', 'int']]})
+	);
+
 
 // Create ffi declarations for the C++ library and functions needed (Kernel32.dll), using their "Unicode" (UTF-16) version
-const kernel32 = new ffi.Library('kernel32', {
+let kernel32;
+kernel32 = (new fastcall.Library('kernel32')
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms684320(v=vs.85).aspx
-	OpenProcess: ['pointer', ['uint32', 'int', 'uint32']],
+	.function({OpenProcess: ['pointer', ['uint32', 'int', 'uint32']]})
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms724211(v=vs.85).aspx
-	CloseHandle: ['int', ['pointer']],
+	.function({CloseHandle: ['int', ['pointer']]})
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms684919(v=vs.85).aspx
-	QueryFullProcessImageNameW: ['int', ['pointer', 'uint32', 'pointer', 'pointer']]
-});
+	.function({QueryFullProcessImageNameW: ['int', ['pointer', 'uint32', 'pointer', 'pointer']]}));
 
 module.exports = () => {
 	// Windows C++ APIs' functions are declared with capitals, so this rule has to be turned off.
 	/* eslint new-cap: off */
 
 	// Get a "handle" of the active window
-	const activeWindowHandle = user32.GetForegroundWindow();
+	const activeWindowHandle = user32.interface.GetForegroundWindow();
+	// Get the Window ID, as GWL_ID
+	const windowId = user32.interface.GetWindowLongW(activeWindowHandle, GWL_ID);
 	// Get the window text length in "characters", to create the buffer
-	const windowTextLength = user32.GetWindowTextLengthW(activeWindowHandle);
+	const windowTextLength = user32.interface.GetWindowTextLengthW(activeWindowHandle);
 	// Allocate a buffer large enough to hold the window text as "Unicode" (UTF-16) characters (using ref-wchar)
 	// This assumes using the "Basic Multilingual Plane" of Unicode, only 2 characters per Unicode code point
 	// Include some extra bytes for possible null characters
 	const windowTextBuffer = Buffer.alloc((windowTextLength * 2) + 4);
 	// Write the window text to the buffer (it returns the text size, but is not used here)
-	user32.GetWindowTextW(activeWindowHandle, windowTextBuffer, windowTextLength + 2);
+	user32.interface.GetWindowTextW(activeWindowHandle, windowTextBuffer, windowTextLength + 2);
 	// Remove trailing null characters
 	const windowTextBufferClean = ref.reinterpretUntilZeros(windowTextBuffer, wchar.size);
 	// The the text as a Javascript string
@@ -53,11 +63,11 @@ module.exports = () => {
 	// Allocate a buffer to store the process ID
 	const processIdBuffer = ref.alloc('uint32');
 	// Write the process ID creating the window to the buffer (it returns the thread ID, but is not used here)
-	user32.GetWindowThreadProcessId(activeWindowHandle, processIdBuffer);
+	user32.interface.GetWindowThreadProcessId(activeWindowHandle, processIdBuffer);
 	// Get the process ID as a number from the buffer
 	const processId = ref.get(processIdBuffer);
 	// Get a "handle" of the process
-	const processHandle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, processId);
+	const processHandle = kernel32.interface.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, processId);
 	// Set the path length to more than the Windows extended-length MAX_PATH length
 	const pathLengthBytes = 66000;
 	// Path length in "characters"
@@ -67,7 +77,7 @@ module.exports = () => {
 	// Create a buffer containing the allocated size for the path, as a buffer as it must be writable
 	const processFileNameSizeBuffer = ref.alloc('uint32', pathLengthChars);
 	// Write process file path to buffer
-	kernel32.QueryFullProcessImageNameW(processHandle, 0, processFileNameBuffer, processFileNameSizeBuffer);
+	kernel32.interface.QueryFullProcessImageNameW(processHandle, 0, processFileNameBuffer, processFileNameSizeBuffer);
 	// Remove null characters from buffer
 	const processFileNameBufferClean = ref.reinterpretUntilZeros(processFileNameBuffer, wchar.size);
 	// Get process file path as a string
@@ -75,12 +85,12 @@ module.exports = () => {
 	// Get process file name from path
 	const processName = path.basename(processPath);
 	// Close the "handle" of the process
-	kernel32.CloseHandle(processHandle);
+	kernel32.interface.CloseHandle(processHandle);
 
 	return {
 		title: windowTitle,
 		// There doesn't seem to be a notion of "window ID" in Windows, so returning -1
-		id: -1,
+		id: windowId,
 		app: processName,
 		pid: processId
 	};

--- a/windows.js
+++ b/windows.js
@@ -11,10 +11,6 @@ const ref = fastcall.ref;
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms684880(v=vs.85).aspx
 const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
 
-// Used by GetWindowLong
-// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633584(v=vs.85).aspx
-const GWL_ID = -12;
-
 // Create ffi declarations for the C++ library and functions needed (User32.dll), using their "Unicode" (UTF-16) version
 const user32 = new fastcall.Library('User32.dll')
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633505(v=vs.85).aspx

--- a/windows.js
+++ b/windows.js
@@ -11,16 +11,23 @@ const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
 
 // ffi declarations for the C++ library and functions needed (User32.dll), using their "Unicode" (UTF-16) version
 const user32 = ffi.Library('user32', {
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633505(v=vs.85).aspx
 	'GetForegroundWindow': ['pointer', []],
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633520(v=vs.85).aspx
 	'GetWindowTextW': ['int', ['pointer', 'pointer', 'int']],
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633521(v=vs.85).aspx
 	'GetWindowTextLengthW': ['int', ['pointer']],
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633522(v=vs.85).aspx
 	'GetWindowThreadProcessId': ['uint32', ['pointer', 'uint32 *']],
 });
 
 // ffi declarations for the C++ library and functions needed (Kernel32.dll), using their "Unicode" (UTF-16) version
 const kernel32 = ffi.Library('kernel32', {
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms684320(v=vs.85).aspx
 	'OpenProcess': ['pointer', ['uint32', 'int', 'uint32']],
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms724211(v=vs.85).aspx
 	'CloseHandle': ['int', ['pointer']],
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms684919(v=vs.85).aspx
 	'QueryFullProcessImageNameW': ['int', ['pointer', 'uint32', 'pointer', 'pointer']],
 });
 
@@ -54,16 +61,23 @@ module.exports = () => {
 	const pathLengthChars = Math.floor(pathLengthBytes / 2);
 	// Allocate a buffer to store the path of the process
 	const processFileNameBuffer = Buffer.alloc(pathLengthBytes);
-	// Create a buffer contain
+	// Create a buffer containing the allocated size for the path, as a buffer as it must be writable
 	const processFileNameSizeBuffer = ref.alloc('uint32', pathLengthChars);
+	// Write process file path to buffer
 	kernel32.QueryFullProcessImageNameW(processHandle, 0, processFileNameBuffer, processFileNameSizeBuffer);
+	// Remove null characters from buffer
 	const processFileNameBufferClean = ref.reinterpretUntilZeros(processFileNameBuffer, wchar_t.size);
+	// Get process file path as a string
 	const processPath = wchar_t.toString(processFileNameBufferClean);
+	// Get process file name from path
 	const processName = path.basename(processPath);
+	// Close the "handle" of the process
+	kernel32.CloseHandle(processHandle);
 
 	return {
 		title: windowTitle,
-		id: 0,
+		// There doesn't seem to be a notion of "window ID" in Windows, so returning -1
+		id: -1,
 		app: processName,
 		pid: processId,
 	};


### PR DESCRIPTION
# Windows support! :tada: 

This uses [ffi](https://github.com/node-ffi/node-ffi/), and some of the familiar packages (`ref` and `ref-wchar`) and adds them as dependencies.

It uses the Windows C++ APIs (via `ffi` and family).

It is all implemented in an additional `windows.js` file, that is required conditionally.

The code is commented in each part to explain how it works, as working with `ffi` and interacting with C++ via Buffers can get a bit tangled (apart from the not-so-good Windows APIs documentation).

---

**Note**: It is based on the code of the PR: https://github.com/sindresorhus/active-win/pull/6 . So it assumes that PR being merged. Nevertheless, it only changes a couple lines from the base code from that PR. So, if we need to change that PR further it won't complicate things too much.