### PR TITLE
Add `appPath` property on Windows

### DIFF
--- a/lib/windows.js
+++ b/lib/windows.js
@@ -84,6 +84,7 @@ function windows() {
 		title: windowTitle,
 		id: windowId,
 		app: processName,
+		appPath: processPath,
 		pid: processId
 	};
 }

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,7 @@ Returns the result `Object`.
 - `title` - Window title
 - `id` - Window ID
 - `app` - App owning the window
+- `appPath` - on Windows only returns the path to the app executable
 - `pid` - Process ID of the app owning the window
 
 

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ Returns the result `Object`.
 - `title` - Window title
 - `id` - Window ID
 - `app` - App owning the window
-- `appPath` - on Windows only returns the path to the app executable
+- `appPath` - Path to the app executable (Windows only)
 - `pid` - Process ID of the app owning the window
 
 


### PR DESCRIPTION
For https://github.com/sindresorhus/active-win/issues/16 it's just a case of using the already available application path for Windows.
I don't know how to replicate this for Mac and Linux though