### PR TITLE
Handle windows with missing title on macOS

### DIFF
--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -34,7 +34,7 @@ for window in windows {
 	let app = NSRunningApplication(processIdentifier: appPid)!
 
 	let dict: [String: Any] = [
-		"title": (window[kCGWindowName as String] != nil ? window[kCGWindowName as String] as! String : "" ),
+		"title": window[kCGWindowName as String] as? String ?? "",
 		"id": window[kCGWindowNumber as String] as! Int,
 		"bounds": [
 			"x": bounds.origin.x,

--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -34,7 +34,7 @@ for window in windows {
 	let app = NSRunningApplication(processIdentifier: appPid)!
 
 	let dict: [String: Any] = [
-		"title": window[kCGWindowName as String] as! String,
+		"title": (window[kCGWindowName as String] != nil ? window[kCGWindowName as String] as! String : "" ),
 		"id": window[kCGWindowNumber as String] as! Int,
 		"bounds": [
 			"x": bounds.origin.x,


### PR DESCRIPTION
Check attribute title of window if exist. Some application (like WhatsApp macos) doesn't has title attribute.

Before hotfix I've got error on active window of WhatsApp app (desktop on mac os): 
Fatal error: Unexpectedly found nil while unwrapping an Optional value
[1]    57782 illegal hardware instruction  .build/debug/active-win

