### PR TITLE
Migrate from `ffi` module to `ffi-napi`

### DIFF
--- a/lib/windows.js
+++ b/lib/windows.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-unresolved */
 'use strict';
 const path = require('path');
-const ffi = require('ffi');
+const ffi = require('ffi-napi');
 const wchar = require('ref-wchar');
 const ref = require('ref');
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"xo": "^0.23.0"
 	},
 	"optionalDependencies": {
-		"ffi": "^2.2.0",
+		"ffi-napi": "^2.4.3",
 		"ref": "^1.3.4",
 		"ref-wchar": "^1.0.2"
 	}


### PR DESCRIPTION
Package [node-ffi](https://github.com/node-ffi/node-ffi) is no longer maintained. Updated to [node-ffi-napi](https://github.com/node-ffi-napi/node-ffi-napi) which has same API.

> WARNING: The original API of node-ffi is left mostly untouched in the N-API wrapper. However, the API did not have very well-defined properties in the context of garbage collection and multi-threaded execution. It is recommended to avoid any multi-threading usage of this library if possible.