### PR TITLE
Fix #32 - MacOS crash when Desktop becomes the active window

### DIFF
--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -54,3 +54,19 @@ for window in windows {
 	print(try! toJson(dict))
 	exit(0)
 }
+
+// If we reach here, it means there was no active window (according to the conditions above).
+// Rather than crash out, assume the active window is the Desktop (Finder)
+let app = NSRunningApplication(processIdentifier: frontmostAppPID)!
+
+let dict: [String: Any] = [
+	"title": "Desktop",
+	"owner": [
+  	"name": "Desktop",
+	  "processId": frontmostAppPID,
+	  "bundleId": app.bundleIdentifier!,
+	  "path": app.bundleURL!.path
+  ]
+]
+print(try! toJson(dict))
+exit(0)

--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -56,17 +56,6 @@ for window in windows {
 }
 
 // If we reach here, it means there was no active window (according to the conditions above).
-// Rather than crash out, assume the active window is the Desktop (Finder)
-let app = NSRunningApplication(processIdentifier: frontmostAppPID)!
-
-let dict: [String: Any] = [
-	"title": "Desktop",
-	"owner": [
-  	"name": "Desktop",
-	  "processId": frontmostAppPID,
-	  "bundleId": app.bundleIdentifier!,
-	  "path": app.bundleURL!.path
-  ]
-]
-print(try! toJson(dict))
+// Rather than crash out, print "null", which is valid JSON
+print("null")
 exit(0)

--- a/test.js
+++ b/test.js
@@ -18,3 +18,7 @@ test('async', async t => {
 test('sync', t => {
 	asserter(t, activeWin.sync());
 });
+
+test('JSON parses "null" string into null value', t => {
+	t.is(JSON.parse('null'), null);
+});


### PR DESCRIPTION
Fixes #32. 

The Desktop window does not appear in the `window` collection because of the `excludeDesktopElements` flag - which is reasonable as you probably don't want icons and the System menu showing up in the results. However, this causes the crash that was identified in issue #32.

This PR prevents the system from crashing out when the active window is not in the `window` collection by return a "fake" Desktop result.