### PR TITLE
Return `undefined` if `activeWindowId`  is falsy on Linux

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -53,6 +53,9 @@ const getActiveWindowId = activeWindowIdStdout => parseInt(activeWindowIdStdout.
 module.exports = async () => {
 	const {stdout: activeWindowIdStdout} = await execFile(xpropBin, xpropActiveArgs);
 	const activeWindowId = getActiveWindowId(activeWindowIdStdout);
+	if (!activeWindowId) {
+		return;
+	}
 
 	const [{stdout}, {stdout: boundsStdout}] = await Promise.all([
 		execFile(xpropBin, xpropDetailsArgs.concat([activeWindowId])),
@@ -69,6 +72,10 @@ module.exports = async () => {
 module.exports.sync = () => {
 	const activeWindowIdStdout = childProcess.execFileSync(xpropBin, xpropActiveArgs, {encoding: 'utf8'});
 	const activeWindowId = getActiveWindowId(activeWindowIdStdout);
+	if (!activeWindowId) {
+		return;
+	}
+
 	const stdout = childProcess.execFileSync(xpropBin, xpropDetailsArgs.concat(activeWindowId), {encoding: 'utf8'});
 	const boundsStdout = childProcess.execFileSync(xwininfoBin, xpropDetailsArgs.concat([activeWindowId]), {encoding: 'utf8'});
 


### PR DESCRIPTION
Currently if a "window" with id 0 is active, executing `active-win` will fail with:

```
(node:23889) UnhandledPromiseRejectionWarning: Error: Command failed: xprop -id 0
xprop: error: Invalid window id format: 0.
```

To reproduce the error one can run `active-win` in a short interval, then run `notify-send foo` and hover over the notification, which results in the rejection.

This patch checks for a falsy `activeWindowId` and returns `undefined` in that case.

What's interesting is, that if the error occurs the cursor changes from a mousepointer to a "plus sign cursor" and only changes back to a mouse cursor if a mousebutton is clicked.
