### PR TITLE
Return `undefined` if `WM_CLASS(STRING)` or `_NET_WM_NAME(UTF8_STRING)` are falsy on Linux

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -25,6 +25,10 @@ const processOutput = output => {
 
 const parseLinux = ({stdout, boundsStdout, activeWindowId}) => {
 	const result = processOutput(stdout);
+	if (!result['WM_CLASS(STRING)']) {
+		return;
+	}
+
 	const bounds = processOutput(boundsStdout);
 
 	const windowIdProperty = 'WM_CLIENT_LEADER(WINDOW)';

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -25,7 +25,7 @@ const processOutput = output => {
 
 const parseLinux = ({stdout, boundsStdout, activeWindowId}) => {
 	const result = processOutput(stdout);
-	if (!result['WM_CLASS(STRING)']) {
+	if (!result['WM_CLASS(STRING)'] || !result['_NET_WM_NAME(UTF8_STRING)']) {
 		return;
 	}
 


### PR DESCRIPTION
It's possible that the result of the call to `xprop` doesn't contain `WM_CLASS(STRING)`, e.g. the Android Studio Device Emulator on Linux

<details>
<summary>returns this</summary>

```
{ '_NET_WM_STATE(ATOM)': '_NET_WM_STATE_FOCUSED',
  'WM_STATE(WM_STATE)': '',
  'window state': 'Normal',
  'icon window': '0x0',
  '_NET_WM_DESKTOP(CARDINAL)': '2',
  '_GTK_EDGE_CONSTRAINTS(CARDINAL)': '170',
  '_NET_WM_ALLOWED_ACTIONS(ATOM)':
   '_NET_WM_ACTION_MOVE, _NET_WM_ACTION_RESIZE, _NET_WM_ACTION_FULLSCREEN, _NET_WM_ACTION_MINIMIZE, _NET_WM_ACTION_MAXIMIZE_HORZ, _NET_WM_ACTION_MAXIMIZE_VERT, _NET_WM_ACTION_CHANGE_DESKTOP, _NET_WM_ACTION_CLOSE, _NET_WM_ACTION_ABOVE, _NET_WM_ACTION_BELOW',
  '_NET_WM_USER_TIME_WINDOW(WINDOW)': 'window id # 0x440000c',
  '_NET_WM_ICON_NAME(UTF8_STRING)': '',
  '_NET_WM_ICON(CARDINAL)': 'Icon (128 x 128):',
  'XdndAware(ATOM)': 'BITMAP',
  '_NET_WM_NAME(UTF8_STRING)': '"Android Emulator - Nexus_4_API_28:5554"',
  '_MOTIF_WM_HINTS(_MOTIF_WM_HINTS)': '0x2, 0x1, 0x0, 0x0, 0x0',
  '_NET_WM_WINDOW_TYPE(ATOM)':
   '_KDE_NET_WM_WINDOW_TYPE_OVERRIDE, _NET_WM_WINDOW_TYPE_NORMAL',
  '_XEMBED_INFO(_XEMBED_INFO)': '0x0, 0x1',
  'WM_CLIENT_LEADER(WINDOW)': 'window id # 0x4400005',
  'WM_HINTS(WM_HINTS)': '',
  'Client accepts input or input focus': 'True',
  'window id # of group leader': '0x4400005',
  'WM_CLIENT_MACHINE(STRING)': '"pc"',
  '_NET_WM_PID(CARDINAL)': '26399',
  '_NET_WM_SYNC_REQUEST_COUNTER(CARDINAL)': '71303172',
  'WM_PROTOCOLS(ATOM)':
   'protocols  WM_DELETE_WINDOW, WM_TAKE_FOCUS, _NET_WM_PING, _NET_WM_SYNC_REQUEST',
  'WM_NORMAL_HINTS(WM_SIZE_HINTS)': '',
  'user specified location': '123, 130',
  'user specified size': '548 by 960',
  'program specified minimum size': '200 by 200',
  'window gravity': 'Static' }
```
</details>

resulting in the error

```
UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'split' of undefined
at parseLinux (/path/to/active-win/lib/linux.js:39:48)
```

Also, sometimes `_NET_WM_NAME(UTF8_STRING)` is an empty string - not exactly sure when this happens, but it sometimes happens with Atom on Linux, the `xprop` 

<details>
<summary>output in that case is this</summary>

```
{ 'WM_STATE(WM_STATE)': '',
  'window state': 'Normal',
  'icon window': '0x0',
  '_NET_WM_DESKTOP(CARDINAL)': '2',
  '_GTK_EDGE_CONSTRAINTS(CARDINAL)': '170',
  '_NET_WM_ALLOWED_ACTIONS(ATOM)':
   '_NET_WM_ACTION_MOVE, _NET_WM_ACTION_CHANGE_DESKTOP, _NET_WM_ACTION_CLOSE, _NET_WM_ACTION_ABOVE, _NET_WM_ACTION_BELOW',
  '_NET_WM_STATE(ATOM)':
   '_NET_WM_STATE_MODAL, _NET_WM_STATE_SKIP_TASKBAR, _NET_WM_STATE_FOCUSED',
  'WM_HINTS(WM_HINTS)': '',
  'Client accepts input or input focus': 'True',
  'window id # of group leader': '0x5a00001',
  '_GTK_THEME_VARIANT(UTF8_STRING)': '"dark"',
  'WM_TRANSIENT_FOR(WINDOW)': 'window id # 0x5800001',
  'XdndAware(ATOM)': 'BITMAP',
  '_NET_WM_OPAQUE_REGION(CARDINAL)': '42, 32, 578, 6, 36, 38, 590, 141',
  '_GTK_FRAME_EXTENTS(CARDINAL)': '36, 38, 32, 42',
  '_MOTIF_WM_HINTS(_MOTIF_WM_HINTS)': '0x2, 0x0, 0x0, 0x0, 0x0',
  '_NET_WM_WINDOW_TYPE(ATOM)': '_NET_WM_WINDOW_TYPE_DIALOG',
  '_NET_WM_SYNC_REQUEST_COUNTER(CARDINAL)': '94375524, 94375525',
  '_NET_WM_USER_TIME_WINDOW(WINDOW)': 'window id # 0x5a00e63',
  'WM_CLIENT_LEADER(WINDOW)': 'window id # 0x5a00001',
  '_NET_WM_PID(CARDINAL)': '9977',
  'WM_LOCALE_NAME(STRING)': '"en_US.UTF-8"',
  'WM_CLIENT_MACHINE(STRING)': '"pc"',
  'WM_NORMAL_HINTS(WM_SIZE_HINTS)': '',
  'program specified minimum size': '664 by 221',
  'program specified maximum size': '664 by 221',
  'program specified base size': '0 by 0',
  'window gravity': 'NorthWest',
  'WM_PROTOCOLS(ATOM)':
   'protocols  WM_DELETE_WINDOW, WM_TAKE_FOCUS, _NET_WM_PING, _NET_WM_SYNC_REQUEST',
  'WM_CLASS(STRING)': '"atom", "Atom"',
  'WM_ICON_NAME(STRING)': '',
  '_NET_WM_ICON_NAME(UTF8_STRING)': '',
  'WM_NAME(STRING)': '',
  '_NET_WM_NAME(UTF8_STRING)': '' }
```
</details>

resulting in the error

```
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at parseLinux (/path/to/active-win/lib/linux.js:39:10)
```

This change returns `undefined` if `WM_CLASS(STRING)` or `_NET_WM_NAME(UTF8_STRING)` are falsy, since [you said](https://github.com/sindresorhus/active-win/pull/42#issuecomment-478906874) you'd prefer returning `undefined` instead of incomplete information.
