### PR TITLE
Fix Linux window name logic for xterm

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -45,7 +45,7 @@ const parseLinux = ({stdout, boundsStdout, activeWindowId}) => {
 
 	return {
 		platform: 'linux',
-		title: JSON.parse(result['_NET_WM_NAME(UTF8_STRING)']) || null,
+		title: JSON.parse(result['_NET_WM_NAME(UTF8_STRING)'] || result['WM_NAME(STRING)']) || null,
 		id: windowId,
 		owner: {
 			name: JSON.parse(result['WM_CLASS(STRING)'].split(',').pop()),


### PR DESCRIPTION
_NET_WM_NAME doesn't exist in the output results, but WM_NAME does