### PR TITLE
Add permission prompts for macOS Catalina

### DIFF
--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -15,9 +15,11 @@ let frontmostAppPID = NSWorkspace.shared.frontmostApplication!.processIdentifier
 let windows = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as! [[String: Any]]
 
 // Show screen recording permissions screen if not enabled; required to get the complete window title
-if CGWindowListCreateImage(.null, .optionIncludingWindow, windows[0][kCGWindowNumber as String] as! CGWindowID, [.boundsIgnoreFraming, .bestResolution]) == nil {
-    print("Active-Win requires permission for screen recording in System Preferences > Security & Privacy > Privacy > Screen Recording.")
-    exit(1)
+if let firstWindow = windows.first {
+    if CGWindowListCreateImage(.null, .optionIncludingWindow, firstWindow[kCGWindowNumber as String] as! CGWindowID, [.boundsIgnoreFraming, .bestResolution]) == nil {
+        print("Active-Win requires permission for screen recording in System Preferences > Security & Privacy > Privacy > Screen Recording.")
+        exit(1)
+    }
 }
 
 for window in windows {

--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -5,21 +5,23 @@ func toJson<T>(_ data: T) throws -> String {
 	return String(data: json, encoding: .utf8)!
 }
 
-// Show accessibility permissions screen if not enabled; required to get the complete window title
+// Show accessibility permission prompt if needed. Required to get the complete window title.
 if !AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary) {
-	print("Active-Win requires permission for accessibility in System Preferences > Security & Privacy > Privacy > Accessibility.")
+	print("active-win requires the accessibility permission in “System Preferences › Security & Privacy › Privacy › Accessibility”.")
 	exit(1)
 }
 
 let frontmostAppPID = NSWorkspace.shared.frontmostApplication!.processIdentifier
 let windows = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as! [[String: Any]]
 
-// Show screen recording permissions screen if not enabled; required to get the complete window title
-if let firstWindow = windows.first {
-    if CGWindowListCreateImage(.null, .optionIncludingWindow, firstWindow[kCGWindowNumber as String] as! CGWindowID, [.boundsIgnoreFraming, .bestResolution]) == nil {
-        print("Active-Win requires permission for screen recording in System Preferences > Security & Privacy > Privacy > Screen Recording.")
-        exit(1)
-    }
+// Show screen recording permission prompt if needed. Required to get the complete window title.
+if
+	let firstWindow = windows.first,
+	let windowNumber = firstWindow[kCGWindowNumber as String] as? CGWindowID,
+	CGWindowListCreateImage(.null, .optionIncludingWindow, windowNumber, [.boundsIgnoreFraming, .bestResolution]) == nil
+{
+	print("active-win requires the screen recording permission in “System Preferences › Security & Privacy › Privacy › Screen Recording”.")
+	exit(1)
 }
 
 for window in windows {

--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -6,8 +6,8 @@ func toJson<T>(_ data: T) throws -> String {
 }
 
 if !AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary) {
-    print("BActive-Win requires permission for accessibility in System Preferences > Security & Privacy > Privacy > Accessibility.")
-    exit(0)
+	print("BActive-Win requires permission for accessibility in System Preferences > Security & Privacy > Privacy > Accessibility.")
+	exit(0)
 }
 
 let frontmostAppPID = NSWorkspace.shared.frontmostApplication!.processIdentifier
@@ -16,8 +16,8 @@ let windows = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopEl
 let windowImage = CGWindowListCreateImage(.null, .optionIncludingWindow, windows[0][kCGWindowNumber as String] as! CGWindowID, [.boundsIgnoreFraming, .bestResolution])
 
 if windowImage == nil {
-    print("Active-Win requires permission for screen recording in System Preferences > Security & Privacy > Privacy > Screen Recording.")
-    exit(0)
+	print("Active-Win requires permission for screen recording in System Preferences > Security & Privacy > Privacy > Screen Recording.")
+	exit(0)
 }
 
 for window in windows {

--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -5,8 +5,20 @@ func toJson<T>(_ data: T) throws -> String {
 	return String(data: json, encoding: .utf8)!
 }
 
+if !AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary) {
+    print("BActive-Win requires permission for accessibility in System Preferences > Security & Privacy > Privacy > Accessibility.")
+    exit(0)
+}
+
 let frontmostAppPID = NSWorkspace.shared.frontmostApplication!.processIdentifier
 let windows = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as! [[String: Any]]
+
+let windowImage = CGWindowListCreateImage(.null, .optionIncludingWindow, windows[0][kCGWindowNumber as String] as! CGWindowID, [.boundsIgnoreFraming, .bestResolution])
+
+if windowImage == nil {
+    print("Active-Win requires permission for screen recording in System Preferences > Security & Privacy > Privacy > Screen Recording.")
+    exit(0)
+}
 
 for window in windows {
 	let windowOwnerPID = window[kCGWindowOwnerPID as String] as! Int

--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -5,19 +5,19 @@ func toJson<T>(_ data: T) throws -> String {
 	return String(data: json, encoding: .utf8)!
 }
 
+// Show accessibility permissions screen if not enabled; required to get the complete window title
 if !AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary) {
-	print("BActive-Win requires permission for accessibility in System Preferences > Security & Privacy > Privacy > Accessibility.")
-	exit(0)
+	print("Active-Win requires permission for accessibility in System Preferences > Security & Privacy > Privacy > Accessibility.")
+	exit(1)
 }
 
 let frontmostAppPID = NSWorkspace.shared.frontmostApplication!.processIdentifier
 let windows = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as! [[String: Any]]
 
-let windowImage = CGWindowListCreateImage(.null, .optionIncludingWindow, windows[0][kCGWindowNumber as String] as! CGWindowID, [.boundsIgnoreFraming, .bestResolution])
-
-if windowImage == nil {
-	print("Active-Win requires permission for screen recording in System Preferences > Security & Privacy > Privacy > Screen Recording.")
-	exit(0)
+// Show screen recording permissions screen if not enabled; required to get the complete window title
+if CGWindowListCreateImage(.null, .optionIncludingWindow, windows[0][kCGWindowNumber as String] as! CGWindowID, [.boundsIgnoreFraming, .bestResolution]) == nil {
+    print("Active-Win requires permission for screen recording in System Preferences > Security & Privacy > Privacy > Screen Recording.")
+    exit(1)
 }
 
 for window in windows {


### PR DESCRIPTION
This update adds permissions prompt for MacOS Catalina to allow active-win to get window title.