### PR TITLE
Add `.url` property for URL of active browser tab on macOS

### DIFF
--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -14,6 +14,8 @@ func getActiveBrowserTabURLAppleScriptCommand(_ appName: String) -> String? {
 		return "tell app \"Safari\" to get URL of front document"
 	case "Brave Browser":
 		return "tell app \"Brave Browser\" to get the url of the active tab of window 1"
+	case "Microsoft Edge":
+		return "tell app \"Microsoft Edge\" to get the url of the active tab of window 1"
 	default:
 		return nil
 	}

--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -5,23 +5,19 @@ func runAppleScript(source: String) -> String? {
 	NSAppleScript(source: source)?.executeAndReturnError(nil).stringValue
 }
 
-// Formats the AppleScript command for Chrome, Safari, Brave, and Edge
+// Format the AppleScript command for Chrome, Safari, Brave, and Edge
 func getActiveBrowserTabURLAppleScriptCommand(_ appName: String) -> String? {
 	switch appName {
-	case "Google Chrome":
-		return "tell app \"Google Chrome\" to get the url of the active tab of window 1"
+	case "Google Chrome", "Brave Browser", "Microsoft Edge":
+		return "tell app \"\(appName)\" to get the URL of active tab of front window"
 	case "Safari":
 		return "tell app \"Safari\" to get URL of front document"
-	case "Brave Browser":
-		return "tell app \"Brave Browser\" to get the url of the active tab of window 1"
-	case "Microsoft Edge":
-		return "tell app \"Microsoft Edge\" to get the url of the active tab of window 1"
 	default:
 		return nil
 	}
 }
 
-// Shows the system prompt if there's no permission.
+// Show the system prompt if there's no permission.
 func hasScreenRecordingPermission() -> Bool {
 	CGDisplayStream(
 		dispatchQueueDisplay: CGMainDisplayID(),
@@ -34,7 +30,7 @@ func hasScreenRecordingPermission() -> Bool {
 	) != nil
 }
 
-// Serializes data dict to JSON
+// Serialize data dict to JSON
 func toJson<T>(_ data: T) throws -> String {
 	let json = try JSONSerialization.data(withJSONObject: data)
 	return String(data: json, encoding: .utf8)!
@@ -100,6 +96,7 @@ for window in windows {
 		"memoryUsage": window[kCGWindowMemoryUsage as String] as! Int
 	]
 
+	// Only run the AppleScript if active window is a compatible browser
 	if browserURLAppleScriptCommand != nil {
 		let browserURL = runAppleScript(source: browserURLAppleScriptCommand!)
 		if browserURL != nil {

--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -10,12 +10,7 @@ func getBrowserURL(_ appName: String) -> String? {
 	guard let script = NSAppleScript(source: scriptText) else { return nil }
 	guard let outputString = script.executeAndReturnError(&error).stringValue else { return nil }
 	
-	// Parse URL and return if present
-	if let url = URL(string: outputString) {
-		return url
-	}
-
-	return nil
+	return outputString
 }
 
 // Formats the AppleScript text for Chrome and Safari
@@ -25,8 +20,8 @@ func getScriptText(_ appName: String) -> String? {
 		return "tell app \"Google Chrome\" to get the url of the active tab of window 1"
 	case "Safari":
 		return "tell application \"Safari\" to return URL of front document"
-	case "Firefox":
-		return "`tell application \"Firefox\" to activate\r\ntell application \"System Events\"\r\nkeystroke \"l\" using command down\r\nkeystroke \"c\" using command down\r\nend tell\r\ndelay 0.5\r\nreturn the clipboard`"
+	case "Brave Browser":
+		return "tell app \"Brave Browser\" to get the url of the active tab of window 1"
 	default:
 		return nil
 	}
@@ -93,7 +88,7 @@ for window in windows {
 	let appName = window[kCGWindowOwnerName as String] as! String
 	let browserURL = getBrowserURL(appName)
 
-	let dict: [String: Any] = [
+	var dict: [String: Any] = [
 		"title": window[kCGWindowName as String] as? String ?? "",
 		"id": window[kCGWindowNumber as String] as! Int,
 		"bounds": [
@@ -111,8 +106,8 @@ for window in windows {
 		"memoryUsage": window[kCGWindowMemoryUsage as String] as! Int
 	]
 
-	if browserURL {
-		dict["owner"]["url"] = browserURL as String? ?? ""
+	if browserURL != nil {
+		dict["url"] = browserURL as String? ?? ""
 	}
 
 	print(try! toJson(dict))

--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -1,13 +1,8 @@
 import AppKit
 
-// Uses AppleScript to get the browser URL from Chrome, Safari, Brave, and Edge
-func getActiveBrowserTabURL(_ scriptCommand: String) -> String? {
-	// Prepare and execute AppleScript command to query URL
-	var error: NSDictionary?
-	guard let script = NSAppleScript(source: scriptCommand) else { return nil }
-	guard let outputString = script.executeAndReturnError(&error).stringValue else { return nil }
-	
-	return outputString
+@discardableResult
+func runAppleScript(source: String) -> String? {
+	NSAppleScript(source: source)?.executeAndReturnError(nil).stringValue
 }
 
 // Formats the AppleScript command for Chrome, Safari, Brave, and Edge
@@ -104,7 +99,10 @@ for window in windows {
 	]
 
 	if browserURLAppleScriptCommand != nil {
-		dict["url"] = getActiveBrowserTabURL(browserURLAppleScriptCommand)
+		let browserURL = runAppleScript(source: browserURLAppleScriptCommand!)
+		if browserURL != nil {
+			dict["url"] = browserURL
+		}
 	}
 
 	print(try! toJson(dict))

--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -75,8 +75,8 @@ for window in windows {
 
 	// This can't fail as we're only dealing with apps
 	let app = NSRunningApplication(processIdentifier: appPid)!
+	
 	let appName = window[kCGWindowOwnerName as String] as! String
-	let browserURLAppleScriptCommand = getActiveBrowserTabURLAppleScriptCommand(appName)
 
 	var dict: [String: Any] = [
 		"title": window[kCGWindowName as String] as? String ?? "",
@@ -97,11 +97,11 @@ for window in windows {
 	]
 
 	// Only run the AppleScript if active window is a compatible browser
-	if browserURLAppleScriptCommand != nil {
-		let browserURL = runAppleScript(source: browserURLAppleScriptCommand!)
-		if browserURL != nil {
-			dict["url"] = browserURL
-		}
+	if
+		let script = getActiveBrowserTabURLAppleScriptCommand(appName),
+		let url = runAppleScript(source: script)
+	{
+		dict["url"] = url
 	}
 
 	print(try! toJson(dict))

--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -1,10 +1,7 @@
 import AppKit
 
 // Uses AppleScript to get the browser URL from Chrome, Safari, Brave, and Edge
-func getActiveBrowserTabURL(_ appName: String) -> String? {
-	// Gets the appropriate AppleScript for each browser type
-	guard let scriptCommand = getActiveBrowserTabURLAppleScriptCommand(appName) else { return nil }
-	
+func getActiveBrowserTabURL(_ scriptCommand: String) -> String? {
 	// Prepare and execute AppleScript command to query URL
 	var error: NSDictionary?
 	guard let script = NSAppleScript(source: scriptCommand) else { return nil }
@@ -86,7 +83,7 @@ for window in windows {
 	// This can't fail as we're only dealing with apps
 	let app = NSRunningApplication(processIdentifier: appPid)!
 	let appName = window[kCGWindowOwnerName as String] as! String
-	let browserURL = getActiveBrowserTabURL(appName)
+	let browserURLAppleScriptCommand = getActiveBrowserTabURLAppleScriptCommand(appName)
 
 	var dict: [String: Any] = [
 		"title": window[kCGWindowName as String] as? String ?? "",
@@ -106,8 +103,8 @@ for window in windows {
 		"memoryUsage": window[kCGWindowMemoryUsage as String] as! Int
 	]
 
-	if browserURL != nil {
-		dict["url"] = browserURL as String? ?? ""
+	if browserURLAppleScriptCommand != nil {
+		dict["url"] = getActiveBrowserTabURL(browserURLAppleScriptCommand)
 	}
 
 	print(try! toJson(dict))

--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -1,20 +1,20 @@
 import AppKit
 
-// Uses AppleScript to get the browser URL from Chrome or Safari
-func getBrowserURL(_ appName: String) -> String? {
+// Uses AppleScript to get the browser URL from Chrome, Safari, Brave, and Edge
+func getActiveBrowserTabURL(_ appName: String) -> String? {
 	// Gets the appropriate AppleScript for each browser type
-	guard let scriptText = getScriptText(appName) else { return nil }
+	guard let scriptCommand = getActiveBrowserTabURLAppleScriptCommand(appName) else { return nil }
 	
-	// Prepare and execute AppleScript script to query URL
+	// Prepare and execute AppleScript command to query URL
 	var error: NSDictionary?
-	guard let script = NSAppleScript(source: scriptText) else { return nil }
+	guard let script = NSAppleScript(source: scriptCommand) else { return nil }
 	guard let outputString = script.executeAndReturnError(&error).stringValue else { return nil }
 	
 	return outputString
 }
 
-// Formats the AppleScript text for Chrome and Safari
-func getScriptText(_ appName: String) -> String? {
+// Formats the AppleScript command for Chrome, Safari, Brave, and Edge
+func getActiveBrowserTabURLAppleScriptCommand(_ appName: String) -> String? {
 	switch appName {
 	case "Google Chrome":
 		return "tell app \"Google Chrome\" to get the url of the active tab of window 1"
@@ -86,7 +86,7 @@ for window in windows {
 	// This can't fail as we're only dealing with apps
 	let app = NSRunningApplication(processIdentifier: appPid)!
 	let appName = window[kCGWindowOwnerName as String] as! String
-	let browserURL = getBrowserURL(appName)
+	let browserURL = getActiveBrowserTabURL(appName)
 
 	var dict: [String: Any] = [
 		"title": window[kCGWindowName as String] as? String ?? "",

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,11 +45,6 @@ declare namespace activeWin {
 		owner: BaseOwner;
 
 		/**
-		URL of the active browser tab if the active window is Safari, Chrome, Edge, or Brave.
-		*/
-		url: string;
-
-		/**
 		Memory usage by the window.
 		*/
 		memoryUsage: number;
@@ -66,6 +61,11 @@ declare namespace activeWin {
 		platform: 'macos';
 
 		owner: MacOSOwner;
+
+		/**
+		URL of the active browser tab if the active window is Safari, Chrome, Edge, or Brave.
+		*/
+		url?: string;
 	}
 
 	interface LinuxResult extends BaseResult {

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,7 +45,7 @@ declare namespace activeWin {
 		owner: BaseOwner;
 
 		/**
-		URL of active browser tab if the active window is Safari, Chrome, or Brave.
+		URL of the active browser tab if the active window is Safari, Chrome, Edge, or Brave.
 		*/
 		url: string;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,11 @@ declare namespace activeWin {
 		owner: BaseOwner;
 
 		/**
+		URL of active browser tab if the active window is Safari, Chrome, or Brave.
+		*/
+		url: string;
+
+		/**
 		Memory usage by the window.
 		*/
 		memoryUsage: number;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -23,7 +23,7 @@ if (result) {
 	if (result.platform === 'macos') {
 		expectType<MacOSResult>(result);
 		expectType<number>(result.owner.bundleId);
-		expectType<string>(result.url);
+		expectType<string | undefined>(result.url);
 	} else if (result.platform === 'linux') {
 		expectType<LinuxResult>(result);
 		expectError(result.owner.bundleId);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -19,6 +19,7 @@ if (result) {
 	expectType<string>(result.owner.name);
 	expectType<number>(result.owner.processId);
 	expectType<string>(result.owner.path);
+	expectType<string>(result.url);
 	expectType<number>(result.memoryUsage);
 	if (result.platform === 'macos') {
 		expectType<MacOSResult>(result);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -19,11 +19,11 @@ if (result) {
 	expectType<string>(result.owner.name);
 	expectType<number>(result.owner.processId);
 	expectType<string>(result.owner.path);
-	expectType<string>(result.url);
 	expectType<number>(result.memoryUsage);
 	if (result.platform === 'macos') {
 		expectType<MacOSResult>(result);
 		expectType<number>(result.owner.bundleId);
+		expectType<string>(result.url);
 	} else if (result.platform === 'linux') {
 		expectType<LinuxResult>(result);
 		expectError(result.owner.bundleId);

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # active-win [![Build Status](https://travis-ci.org/sindresorhus/active-win.svg?branch=master)](https://travis-ci.org/sindresorhus/active-win)
 
-Get metadata about the [active window](https://en.wikipedia.org/wiki/Active_window) (title, id, bounds, owner, etc)
+Get metadata about the [active window](https://en.wikipedia.org/wiki/Active_window) (title, id, bounds, owner, url, etc)
 
 Works on macOS, Linux, Windows.
 
@@ -37,6 +37,7 @@ const activeWin = require('active-win');
 			bundleId: 'com.google.Chrome',
 			path: '/Applications/Google Chrome.app'
 		},
+		url: 'https://google.com/unicorns',
 		memoryUsage: 11015432
 	}
 	*/
@@ -70,6 +71,7 @@ Returns an `Object` with the result, or `undefined` if there is no active window
 	- `processId` *(number)* - Process identifier
 	- `bundleId` *(string)* - Bundle identifier *(macOS only)*
 	- `path` *(string)* - Path to the app
+- `url` *(string)* - URL of active browser tab if the active window is Safari, Chrome, or Brave *(macOS only)*
 - `memoryUsage` *(number)* - Memory usage by the window owner process
 
 

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ Returns an `Object` with the result, or `undefined` if there is no active window
 	- `processId` *(number)* - Process identifier
 	- `bundleId` *(string)* - Bundle identifier *(macOS only)*
 	- `path` *(string)* - Path to the app
-- `url` *(string?)* - URL of the active browser tab if the active window is Safari, Chrome, or Brave *(macOS only)*
+- `url` *(string?)* - URL of the active browser tab if the active window is Safari, Chrome, Edge, or Brave *(macOS only)*
 - `memoryUsage` *(number)* - Memory usage by the window owner process
 
 


### PR DESCRIPTION
Using AppleScript, this PR updates the `main.swift` file to include the ability to get the browser URL for the active window if the browser is Safari, Google Chrome, or Brave. Firefox has a much more difficult implementation in AppleScript requiring additional permissions and could be added at a later date if desired.

Fixes #62, fixes #54, fixes #45, and fixes #20. 