### PR TITLE
Avoid ref.reinterpretUntilZeros as it has issues on Electron

### DIFF
--- a/lib/windows.js
+++ b/lib/windows.js
@@ -77,7 +77,7 @@ function windows() {
 	if (ref.isNull(activeWindowHandle)) {
 		return undefined; // Failed to get active window handle
 	}
-
+	
 	// Get memory address of the window handle as the "window ID"
 	const windowId = ref.address(activeWindowHandle);
 	// Get the window text length in "characters" to create the buffer
@@ -87,11 +87,9 @@ function windows() {
 	// Include some extra bytes for possible null characters
 	const windowTextBuffer = Buffer.alloc((windowTextLength * 2) + 4);
 	// Write the window text to the buffer (it returns the text size, but it's not used here)
-	user32.GetWindowTextW(activeWindowHandle, windowTextBuffer, windowTextLength + 2);
-	// Remove trailing null characters
-	const windowTextBufferClean = ref.reinterpretUntilZeros(windowTextBuffer, wchar.size);
+	const titleSize = user32.GetWindowTextW(activeWindowHandle, windowTextBuffer, windowTextLength + 2);
 	// The text as a JavaScript string
-	const windowTitle = wchar.toString(windowTextBufferClean);
+	const windowTitle = wchar.toString(windowTextBuffer).substr(0, titleSize)
 
 	// Allocate a buffer to store the process ID
 	const processIdBuffer = ref.alloc('uint32');
@@ -116,10 +114,8 @@ function windows() {
 	const processFileNameSizeBuffer = ref.alloc('uint32', pathLengthChars);
 	// Write process file path to buffer
 	kernel32.QueryFullProcessImageNameW(processHandle, 0, processFileNameBuffer, processFileNameSizeBuffer);
-	// Remove null characters from buffer
-	const processFileNameBufferClean = ref.reinterpretUntilZeros(processFileNameBuffer, wchar.size);
 	// Get process file path as a string
-	const processPath = wchar.toString(processFileNameBufferClean);
+	const processPath = wchar.toString(processFileNameBuffer).replace(/\0+/, '')
 	// Get process file name from path
 	const processName = path.basename(processPath);
 

--- a/lib/windows.js
+++ b/lib/windows.js
@@ -77,7 +77,7 @@ function windows() {
 	if (ref.isNull(activeWindowHandle)) {
 		return undefined; // Failed to get active window handle
 	}
-	
+
 	// Get memory address of the window handle as the "window ID"
 	const windowId = ref.address(activeWindowHandle);
 	// Get the window text length in "characters" to create the buffer
@@ -89,7 +89,7 @@ function windows() {
 	// Write the window text to the buffer (it returns the text size, but it's not used here)
 	const titleSize = user32.GetWindowTextW(activeWindowHandle, windowTextBuffer, windowTextLength + 2);
 	// The text as a JavaScript string
-	const windowTitle = wchar.toString(windowTextBuffer).substr(0, titleSize)
+	const windowTitle = wchar.toString(windowTextBuffer).slice(0, titleSize);
 
 	// Allocate a buffer to store the process ID
 	const processIdBuffer = ref.alloc('uint32');
@@ -115,7 +115,7 @@ function windows() {
 	// Write process file path to buffer
 	kernel32.QueryFullProcessImageNameW(processHandle, 0, processFileNameBuffer, processFileNameSizeBuffer);
 	// Get process file path as a string
-	const processPath = wchar.toString(processFileNameBuffer).replace(/\0+/, '')
+	const processPath = wchar.toString(processFileNameBuffer).replace(/\0+/, '');
 	// Get process file name from path
 	const processName = path.basename(processPath);
 

--- a/lib/windows.js
+++ b/lib/windows.js
@@ -115,7 +115,7 @@ function windows() {
 	// Write process file path to buffer
 	kernel32.QueryFullProcessImageNameW(processHandle, 0, processFileNameBuffer, processFileNameSizeBuffer);
 	// Get process file path as a string
-	const processPath = wchar.toString(processFileNameBuffer).replace(/\0+/, '');
+	const processPath = wchar.toString(processFileNameBuffer).replace(/\0+$/, '');
 	// Get process file name from path
 	const processName = path.basename(processPath);
 


### PR DESCRIPTION
Electron seems to crash on these lines in Windows 10. Works fine in Node 12 outside of Electron, so I'm not sure what the problem is. Perhaps @Janealter might have an idea, or an alternate way to strip null characters.