### PR TITLE
Avoid triggering access dialogs on macOS

### DIFF
--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -11,11 +11,12 @@ func getActiveBrowserTabURLAppleScriptCommand(_ appName: String) -> String? {
 	}
 }
 
-let noAccessCheck = CommandLine.arguments.contains("--no-access-check")
-let noAppleScript = CommandLine.arguments.contains("--no-apple-script")
+let doAccessibilityCheck = !CommandLine.arguments.contains("--no-accessibility-check")
+let doScreenRecordingCheck = !CommandLine.arguments.contains("--no-screen-recording-check")
+let doUrl = !CommandLine.arguments.contains("--no-url")
 
 // Show accessibility permission prompt if needed. Required to get the complete window title.
-if !noAccessCheck && !AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary) {
+if doAccessibilityCheck && !AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary) {
 	print("active-win requires the accessibility permission in “System Preferences › Security & Privacy › Privacy › Accessibility”.")
 	exit(1)
 }
@@ -24,7 +25,7 @@ let frontmostAppPID = NSWorkspace.shared.frontmostApplication!.processIdentifier
 let windows = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as! [[String: Any]]
 
 // Show screen recording permission prompt if needed. Required to get the complete window title.
-if !noAccessCheck && !hasScreenRecordingPermission() {
+if doScreenRecordingCheck && !hasScreenRecordingPermission() {
 	print("active-win requires the screen recording permission in “System Preferences › Security & Privacy › Privacy › Screen Recording”.")
 	exit(1)
 }
@@ -76,7 +77,7 @@ for window in windows {
 
 	// Only run the AppleScript if active window is a compatible browser.
 	if
-		!noAppleScript,
+		doUrl,
 		let script = getActiveBrowserTabURLAppleScriptCommand(appName),
 		let url = runAppleScript(source: script)
 	{

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,21 @@
 declare namespace activeWin {
+	interface Options {
+		/**
+		Disable Accessibility permission check (macOS)
+		*/
+		accessibilityCheck: boolean;
+
+		/**
+		Disable Screen Recording permission check (macOS)
+		*/
+		screenRecordingCheck: boolean;
+
+		/**
+		Disable obtaining URL from the active browser tab (macOS)
+		*/
+		url: boolean;
+	}
+
 	interface BaseOwner {
 		/**
 		Name of the app.
@@ -107,7 +124,7 @@ declare const activeWin: {
 	})();
 	```
 	*/
-	(): Promise<activeWin.Result | undefined>;
+	(options?: activeWin.Options): Promise<activeWin.Result | undefined>;
 
 	/**
 	Synchronously get metadata about the [active window](https://en.wikipedia.org/wiki/Active_window) (title, id, bounds, owner, etc).
@@ -132,7 +149,7 @@ declare const activeWin: {
 	}
 	```
 	*/
-	sync(): activeWin.Result | undefined;
+	sync(options?: activeWin.Options): activeWin.Result | undefined;
 };
 
 export = activeWin;

--- a/index.js
+++ b/index.js
@@ -1,32 +1,32 @@
 'use strict';
 
-module.exports = () => {
+module.exports = options => {
 	if (process.platform === 'darwin') {
-		return require('./lib/macos')();
+		return require('./lib/macos')(options);
 	}
 
 	if (process.platform === 'linux') {
-		return require('./lib/linux')();
+		return require('./lib/linux')(options);
 	}
 
 	if (process.platform === 'win32') {
-		return require('./lib/windows')();
+		return require('./lib/windows')(options);
 	}
 
 	return Promise.reject(new Error('macOS, Linux, and Windows only'));
 };
 
-module.exports.sync = () => {
+module.exports.sync = options => {
 	if (process.platform === 'darwin') {
-		return require('./lib/macos').sync();
+		return require('./lib/macos').sync(options);
 	}
 
 	if (process.platform === 'linux') {
-		return require('./lib/linux').sync();
+		return require('./lib/linux').sync(options);
 	}
 
 	if (process.platform === 'win32') {
-		return require('./lib/windows').sync();
+		return require('./lib/windows').sync(options);
 	}
 
 	throw new Error('macOS, Linux, and Windows only');

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -2,9 +2,14 @@ import {expectType, expectError} from 'tsd';
 import activeWin = require('.');
 import {Result, LinuxResult, MacOSResult, WindowsResult} from '.';
 
+
 expectType<Promise<Result | undefined>>(activeWin());
 
-const result = activeWin.sync();
+const result = activeWin.sync({
+	accessibilityCheck: false,
+	screenRecordingCheck: false,
+	url: false,
+});
 
 expectType<Result | undefined>(result);
 

--- a/lib/macos.js
+++ b/lib/macos.js
@@ -25,12 +25,16 @@ const getArguments = options => {
 	}
 
 	const args = [];
-	if (options.accessCheck === false) {
-		args.push('--no-access-check');
+	if (options.accessibilityCheck === false) {
+		args.push('--no-accessibility-check');
 	}
 
-	if (options.appleScript === false) {
-		args.push('--no-apple-script');
+	if (options.screenRecordingCheck === false) {
+		args.push('--no-screen-recording-check');
+	}
+
+	if (options.url === false) {
+		args.push('--no-url');
 	}
 
 	return args;

--- a/lib/macos.js
+++ b/lib/macos.js
@@ -19,9 +19,29 @@ const parseMac = stdout => {
 	}
 };
 
-module.exports = async () => {
-	const {stdout} = await execFile(bin);
+const getArguments = options => {
+	if (!options) {
+		return [];
+	}
+
+	const args = [];
+	if (options.accessCheck === false) {
+		args.push('--no-access-check');
+	}
+
+	if (options.appleScript === false) {
+		args.push('--no-apple-script');
+	}
+
+	return args;
+};
+
+module.exports = async options => {
+	const {stdout} = await execFile(bin, getArguments(options));
 	return parseMac(stdout);
 };
 
-module.exports.sync = () => parseMac(childProcess.execFileSync(bin, {encoding: 'utf8'}));
+module.exports.sync = options => {
+	const stdout = childProcess.execFileSync(bin, getArguments(options), {encoding: 'utf8'});
+	return parseMac(stdout);
+};

--- a/readme.md
+++ b/readme.md
@@ -47,11 +47,17 @@ const activeWin = require('active-win');
 
 ### activeWin()
 
-Returns a `Promise<Object>` with the result, or `Promise<undefined>` if there is no active window or if the information is not available.
+Accepts an optional dictionary `Options` as only argument and returns a `Promise<Object>` with the result, or `Promise<undefined>` if there is no active window or if the information is not available.
 
 ### activeWin.sync()
 
-Returns an `Object` with the result, or `undefined` if there is no active window.
+Accepts an optional dictionary `Options` as only argument and returns an `Object` with the result, or `undefined` if there is no active window.
+
+## Options
+
+- `accessibilityCheck` *(boolean)* - set to `false` to disable that check *(macOS)*
+- `screenRecordingCheck` *(boolean)* - set to `false` to disable that check *(macOS)*
+- `url` *(boolean)* - set to `false` to skip obtaining the URL from a browser *(macOS)*
 
 ## Result
 


### PR DESCRIPTION
Recent macOS versions the operating system is triggering accessibility dialogs asking the user if an operation should be allowed. Our application tries to guide the user through it as part of our onboarding setup.

So it'll be great if we can instruct active-win to skip functionality that would trigger those dialogs. For instance we already ask for the *Screen Recording* permission that provides the *title*, hence we shouldn't need the Accessibility one or inspect Chrome for the *url* since we don't require that information.

These changes allow to pass the following options:

 - `accessCheck: false` -- disables the accessibility checks and so the OS prompts
 - `appleScript: false` -- disables the use of apple script (used to obtain the URL only)

Hopefully this is something most people will find useful. And thanks for the library!