### PR TITLE
Add support for Windows UWP apps

### DIFF
--- a/lib/windows.js
+++ b/lib/windows.js
@@ -16,7 +16,6 @@ const Rect = struct({
 const RectPointer = ref.refType(Rect);
 const VoidPointer = ref.refType(ref.types.void);
 
-
 // Required by QueryFullProcessImageName
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms684880(v=vs.85).aspx
 const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
@@ -35,8 +34,8 @@ const user32 = new ffi.Library('User32.dll', {
 	// https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-getwindowrect
 	GetWindowRect: ['bool', ['pointer', RectPointer]],
 	// Iterate through child windows
-	//https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enumchildwindows
-	EnumChildWindows: ['bool', ['pointer', VoidPointer, 'int32']],
+	// https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enumchildwindows
+	EnumChildWindows: ['bool', ['pointer', VoidPointer, 'int32']]
 });
 
 const SIZE_T = 'uint64';
@@ -73,13 +72,11 @@ const kernel32 = new ffi.Library('kernel32', {
 	QueryFullProcessImageNameW: ['int', ['pointer', 'uint32', 'pointer', 'pointer']]
 });
 
-//Check parent window for SubWindows and find the unique process inside of it.
+// Check parent window for SubWindows and find the unique process inside of it.
 function getSubWindowRealProcessPath(activeWindowHandle, processPath) {
-
 	let newProcessPath;
 
-	const windowProcess = ffi.Callback('bool', ['pointer', 'int32'], (hwnd, lParam) => {
-
+	const windowProcess = ffi.Callback('bool', ['pointer', 'int32'], hwnd => {
 		// Return the Process ID & Process Handle from the Active Window Handle
 		const [, processHandle] = getProcessIdAndHandle(hwnd);
 
@@ -87,7 +84,7 @@ function getSubWindowRealProcessPath(activeWindowHandle, processPath) {
 			return false; // Failed to get process handle
 		}
 
-		let processPathChild = getProcessPath(processHandle);
+		const processPathChild = getProcessPath(processHandle);
 
 		if (processPathChild !== processPath) {
 			newProcessPath = processPathChild;
@@ -104,11 +101,9 @@ function getSubWindowRealProcessPath(activeWindowHandle, processPath) {
 	}
 
 	return processPath;
-
-
 }
-function getProcessPath(processHandle) {
 
+function getProcessPath(processHandle) {
 	if (ref.isNull(processHandle)) {
 		return [undefined, undefined];
 	}
@@ -127,12 +122,12 @@ function getProcessPath(processHandle) {
 	// Remove null characters from buffer
 	const processFileNameBufferClean = ref.reinterpretUntilZeros(processFileNameBuffer, wchar.size);
 	// Get process file path as a string
-	let processPath = wchar.toString(processFileNameBufferClean);
+	const processPath = wchar.toString(processFileNameBufferClean);
 
-	return processPath
+	return processPath;
 }
-function getProcessIdAndHandle(windowHandle) {
 
+function getProcessIdAndHandle(windowHandle) {
 	// Allocate a buffer to store the process ID
 	const processIdBuffer = ref.alloc('uint32');
 	// Write the process ID creating the window to the buffer (it returns the thread ID, but it's not used here)
@@ -144,6 +139,7 @@ function getProcessIdAndHandle(windowHandle) {
 
 	return [processId, processHandle];
 }
+
 function windows() {
 	// Windows C++ APIs' functions are declared with capitals, so this rule has to be turned off
 
@@ -186,8 +182,6 @@ function windows() {
 		processPath = getSubWindowRealProcessPath(activeWindowHandle, processPath);
 		processName = path.basename(processPath);
 	}
-
-
 
 	// Get process memory counters
 	const memoryCounters = new ProcessMemoryCounters();

--- a/lib/windows.js
+++ b/lib/windows.js
@@ -14,7 +14,7 @@ const Rect = struct({
 	bottom: 'long'
 });
 const RectPointer = ref.refType(Rect);
-const VoidPtr = ref.refType(ref.types.void);
+const VoidPointer = ref.refType(ref.types.void);
 
 
 // Required by QueryFullProcessImageName
@@ -34,7 +34,7 @@ const user32 = new ffi.Library('User32.dll', {
 	// Get window bounds function
 	// https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-getwindowrect
 	GetWindowRect: ['bool', ['pointer', RectPointer]],
-	// Iterate through children windows
+	// Iterate through child windows
 	//https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enumchildwindows
 	EnumChildWindows: ['bool', ['pointer', VoidPtr, 'int32']],
 });
@@ -73,6 +73,44 @@ const kernel32 = new ffi.Library('kernel32', {
 	QueryFullProcessImageNameW: ['int', ['pointer', 'uint32', 'pointer', 'pointer']]
 });
 
+function getProcessPathAndName(processHandle) {
+
+	if (ref.isNull(processHandle)) {
+		return [undefined, undefined];
+	}
+
+	// Set the path length to more than the Windows extended-length MAX_PATH length
+	const pathLengthBytes = 66000;
+	// Path length in "characters"
+	const pathLengthChars = Math.floor(pathLengthBytes / 2);
+	// Allocate a buffer to store the path of the process
+	const processFileNameBuffer = Buffer.alloc(pathLengthBytes);
+	// Create a buffer containing the allocated size for the path, as a buffer as it must be writable
+	const processFileNameSizeBuffer = ref.alloc('uint32', pathLengthChars);
+	// Write process file path to buffer
+	kernel32.QueryFullProcessImageNameW(processHandle, 0, processFileNameBuffer, processFileNameSizeBuffer);
+	// Remove null characters from buffer
+	const processFileNameBufferClean = ref.reinterpretUntilZeros(processFileNameBuffer, wchar.size);
+	// Get process file path as a string
+	let processPath = wchar.toString(processFileNameBufferClean);
+	// Get process file name from path
+	let processName = path.basename(processPath);
+
+	return [processPath, processName]
+}
+function getProcessIdAndHandle(windowHandle) {
+
+	// Allocate a buffer to store the process ID
+	const processIdBuffer = ref.alloc('uint32');
+	// Write the process ID creating the window to the buffer (it returns the thread ID, but it's not used here)
+	user32.GetWindowThreadProcessId(windowHandle, processIdBuffer);
+	// Get the process ID as a number from the buffer
+	const processId = ref.get(processIdBuffer);
+	// Get a "handle" of the process
+	const processHandle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, processId);
+
+	return [processId, processHandle];
+}
 function windows() {
 	// Windows C++ APIs' functions are declared with capitals, so this rule has to be turned off
 
@@ -98,69 +136,32 @@ function windows() {
 	// The text as a JavaScript string
 	const windowTitle = wchar.toString(windowTextBufferClean);
 
-	// Allocate a buffer to store the process ID
-	const processIdBuffer = ref.alloc('uint32');
-	// Write the process ID creating the window to the buffer (it returns the thread ID, but it's not used here)
-	user32.GetWindowThreadProcessId(activeWindowHandle, processIdBuffer);
-	// Get the process ID as a number from the buffer
-	const processId = ref.get(processIdBuffer);
-	// Get a "handle" of the process
-	const processHandle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, processId);
+	// Return the Process ID & Process Handle from the Active Window Handle
+	const [processId, processHandle] = getProcessIdAndHandle(activeWindowHandle);
 
 	if (ref.isNull(processHandle)) {
 		return undefined; // Failed to get process handle
 	}
 
-	// Set the path length to more than the Windows extended-length MAX_PATH length
-	const pathLengthBytes = 66000;
-	// Path length in "characters"
-	const pathLengthChars = Math.floor(pathLengthBytes / 2);
-	// Allocate a buffer to store the path of the process
-	const processFileNameBuffer = Buffer.alloc(pathLengthBytes);
-	// Create a buffer containing the allocated size for the path, as a buffer as it must be writable
-	const processFileNameSizeBuffer = ref.alloc('uint32', pathLengthChars);
-	// Write process file path to buffer
-	kernel32.QueryFullProcessImageNameW(processHandle, 0, processFileNameBuffer, processFileNameSizeBuffer);
-	// Remove null characters from buffer
-	const processFileNameBufferClean = ref.reinterpretUntilZeros(processFileNameBuffer, wchar.size);
-	// Get process file path as a string
-	let processPath = wchar.toString(processFileNameBufferClean);
-	// Get process file name from path
-	let processName = path.basename(processPath);
-	let newProcessName = null;
-	let newProcessPath = null;
+	// Return the Process Path & Process Name from a Process Handle
+	let [processPath, processName] = getProcessPathAndName(processHandle);
+
+	let newProcessName;
+	let newProcessPath;
 
 	// ApplicationFrameHost & Universal Windows Platform Support
 	if (processName === 'ApplicationFrameHost.exe') {
-		const windowProc = ffi.Callback('bool', ['pointer', 'int32'], function (hwnd, lParam) {
-			// Allocate a buffer to store the process ID
-			const processIdBufferChild = ref.alloc('uint32');
-			// Write the process ID creating the window to the buffer (it returns the thread ID, but it's not used here)
-			user32.GetWindowThreadProcessId(hwnd, processIdBufferChild);
-			// Get the process ID as a number from the buffer
-			const processIdChild = ref.get(processIdBufferChild);
-			// Get a "handle" of the process
-			const processHandleChild = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, processIdChild);
+
+		const windowProcess = ffi.Callback('bool', ['pointer', 'int32'], (hwnd, lParam) => {
+
+			// Return the Process ID & Process Handle from the Active Window Handle
+			const [processId, processHandle] = getProcessIdAndHandle(hwnd);
+
 			if (ref.isNull(processHandleChild)) {
-				return undefined; // Failed to get process handle
+				return false; // Failed to get process handle
 			}
 
-			// Set the path length to more than the Windows extended-length MAX_PATH length
-			const pathLengthBytesChild = 66000;
-			// Path length in "characters"
-			const pathLengthCharsChild = Math.floor(pathLengthBytesChild / 2);
-			// Allocate a buffer to store the path of the process
-			const processFileNameBufferChild = Buffer.alloc(pathLengthBytesChild);
-			// Create a buffer containing the allocated size for the path, as a buffer as it must be writable
-			const processFileNameSizeBufferChild = ref.alloc('uint32', pathLengthCharsChild);
-			// Write process file path to buffer
-			kernel32.QueryFullProcessImageNameW(processHandleChild, 0, processFileNameBufferChild, processFileNameSizeBufferChild);
-			// Remove null characters from buffer
-			const processFileNameBufferCleanChild = ref.reinterpretUntilZeros(processFileNameBufferChild, wchar.size);
-			// Get process file path as a string
-			const processPathChild = wchar.toString(processFileNameBufferCleanChild);
-			// Get process file name from path
-			const processNameChild = path.basename(processPathChild);
+			let [processPathChild, processNameChild] = getProcessPathAndName(processHandle);
 
 			if (processNameChild !== processName) {
 				newProcessName = processNameChild;
@@ -171,7 +172,7 @@ function windows() {
 		user32.EnumChildWindows(activeWindowHandle, windowProc, 0);
 	}
 
-	if (newProcessName !== null && newProcessName !== processName) {
+	if (newProcessName !== undefined && newProcessName !== processName) {
 		processName = newProcessName;
 		processPath = newProcessPath;
 	}
@@ -200,7 +201,6 @@ function windows() {
 	return {
 		platform: 'windows',
 		title: windowTitle,
-		processPath,
 		id: windowId,
 		owner: {
 			name: processName,

--- a/lib/windows.js
+++ b/lib/windows.js
@@ -110,7 +110,7 @@ function getProcessPath(processHandle) {
 
 	// Set the path length to more than the Windows extended-length MAX_PATH length
 	// The maximum path of 32,767 characters is approximate, because the "\\?\" prefix may be expanded to a longer string by the system at run time, and this expansion applies to the total length.
-	const pathLengthBytes = 36000;
+	const pathLengthBytes = 66000;
 	// Path length in "characters"
 	const pathCharacterCount = Math.floor(pathLengthBytes / 2);
 	// Allocate a buffer to store the path of the process

--- a/lib/windows.js
+++ b/lib/windows.js
@@ -81,7 +81,7 @@ function getSubWindowRealProcessPath(activeWindowHandle, processPath) {
 	const windowProcess = ffi.Callback('bool', ['pointer', 'int32'], (hwnd, lParam) => {
 
 		// Return the Process ID & Process Handle from the Active Window Handle
-		const [processId, processHandle] = getProcessIdAndHandle(hwnd);
+		const [, processHandle] = getProcessIdAndHandle(hwnd);
 
 		if (ref.isNull(processHandle)) {
 			return false; // Failed to get process handle
@@ -91,6 +91,7 @@ function getSubWindowRealProcessPath(activeWindowHandle, processPath) {
 
 		if (processPathChild !== processPath) {
 			newProcessPath = processPathChild;
+			return false;
 		}
 
 		return true;
@@ -113,7 +114,8 @@ function getProcessPath(processHandle) {
 	}
 
 	// Set the path length to more than the Windows extended-length MAX_PATH length
-	const pathLengthBytes = 66000;
+	// The maximum path of 32,767 characters is approximate, because the "\\?\" prefix may be expanded to a longer string by the system at run time, and this expansion applies to the total length.
+	const pathLengthBytes = 36000;
 	// Path length in "characters"
 	const pathLengthChars = Math.floor(pathLengthBytes / 2);
 	// Allocate a buffer to store the path of the process

--- a/lib/windows.js
+++ b/lib/windows.js
@@ -157,7 +157,7 @@ function windows() {
 			// Return the Process ID & Process Handle from the Active Window Handle
 			const [processId, processHandle] = getProcessIdAndHandle(hwnd);
 
-			if (ref.isNull(processHandleChild)) {
+			if (ref.isNull(processHandle)) {
 				return false; // Failed to get process handle
 			}
 
@@ -169,7 +169,7 @@ function windows() {
 			}
 			return true;
 		});
-		user32.EnumChildWindows(activeWindowHandle, windowProc, 0);
+		user32.EnumChildWindows(activeWindowHandle, windowProcess, 0);
 	}
 
 	if (newProcessName !== undefined && newProcessName !== processName) {

--- a/lib/windows.js
+++ b/lib/windows.js
@@ -36,7 +36,7 @@ const user32 = new ffi.Library('User32.dll', {
 	GetWindowRect: ['bool', ['pointer', RectPointer]],
 	// Iterate through child windows
 	//https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enumchildwindows
-	EnumChildWindows: ['bool', ['pointer', VoidPtr, 'int32']],
+	EnumChildWindows: ['bool', ['pointer', VoidPointer, 'int32']],
 });
 
 const SIZE_T = 'uint64';

--- a/lib/windows.js
+++ b/lib/windows.js
@@ -73,7 +73,40 @@ const kernel32 = new ffi.Library('kernel32', {
 	QueryFullProcessImageNameW: ['int', ['pointer', 'uint32', 'pointer', 'pointer']]
 });
 
-function getProcessPathAndName(processHandle) {
+//Check parent window for SubWindows and find the unique process inside of it.
+function getSubWindowRealProceessPath(activeWindowHandle, processPath) {
+
+	let newProcessPath;
+
+	const windowProcess = ffi.Callback('bool', ['pointer', 'int32'], (hwnd, lParam) => {
+
+		// Return the Process ID & Process Handle from the Active Window Handle
+		const [processId, processHandle] = getProcessIdAndHandle(hwnd);
+
+		if (ref.isNull(processHandle)) {
+			return false; // Failed to get process handle
+		}
+
+		let processPathChild = getProcessPath(processHandle);
+
+		if (processPathChild !== processPath) {
+			newProcessPath = processPathChild;
+		}
+
+		return true;
+	});
+
+	user32.EnumChildWindows(activeWindowHandle, windowProcess, 0);
+
+	if (newProcessPath !== undefined && newProcessPath !== processPath) {
+		processPath = newProcessPath;
+	}
+
+	return processPath;
+
+
+}
+function getProcessPath(processHandle) {
 
 	if (ref.isNull(processHandle)) {
 		return [undefined, undefined];
@@ -93,10 +126,8 @@ function getProcessPathAndName(processHandle) {
 	const processFileNameBufferClean = ref.reinterpretUntilZeros(processFileNameBuffer, wchar.size);
 	// Get process file path as a string
 	let processPath = wchar.toString(processFileNameBufferClean);
-	// Get process file name from path
-	let processName = path.basename(processPath);
 
-	return [processPath, processName]
+	return processPath
 }
 function getProcessIdAndHandle(windowHandle) {
 
@@ -144,38 +175,16 @@ function windows() {
 	}
 
 	// Return the Process Path & Process Name from a Process Handle
-	let [processPath, processName] = getProcessPathAndName(processHandle);
-
-	let newProcessName;
-	let newProcessPath;
+	let processPath = getProcessPath(processHandle);
+	// Get process file name from path
+	let processName = path.basename(processPath);
 
 	// ApplicationFrameHost & Universal Windows Platform Support
 	if (processName === 'ApplicationFrameHost.exe') {
-
-		const windowProcess = ffi.Callback('bool', ['pointer', 'int32'], (hwnd, lParam) => {
-
-			// Return the Process ID & Process Handle from the Active Window Handle
-			const [processId, processHandle] = getProcessIdAndHandle(hwnd);
-
-			if (ref.isNull(processHandle)) {
-				return false; // Failed to get process handle
-			}
-
-			let [processPathChild, processNameChild] = getProcessPathAndName(processHandle);
-
-			if (processNameChild !== processName) {
-				newProcessName = processNameChild;
-				newProcessPath = processPathChild;
-			}
-			return true;
-		});
-		user32.EnumChildWindows(activeWindowHandle, windowProcess, 0);
+		processPath = getSubWindowRealProceessPath(activeWindowHandle, processPath);
+		processName = path.basename(processPath);
 	}
 
-	if (newProcessName !== undefined && newProcessName !== processName) {
-		processName = newProcessName;
-		processPath = newProcessPath;
-	}
 
 
 	// Get process memory counters

--- a/lib/windows.js
+++ b/lib/windows.js
@@ -97,7 +97,7 @@ function getSubWindowRealProcessPath(activeWindowHandle, processPath) {
 	user32.EnumChildWindows(activeWindowHandle, windowProcess, 0);
 
 	if (newProcessPath !== undefined && newProcessPath !== processPath) {
-		processPath = newProcessPath;
+		return newProcessPath;
 	}
 
 	return processPath;
@@ -105,18 +105,18 @@ function getSubWindowRealProcessPath(activeWindowHandle, processPath) {
 
 function getProcessPath(processHandle) {
 	if (ref.isNull(processHandle)) {
-		return [undefined, undefined];
+		return undefined;
 	}
 
 	// Set the path length to more than the Windows extended-length MAX_PATH length
 	// The maximum path of 32,767 characters is approximate, because the "\\?\" prefix may be expanded to a longer string by the system at run time, and this expansion applies to the total length.
 	const pathLengthBytes = 36000;
 	// Path length in "characters"
-	const pathLengthChars = Math.floor(pathLengthBytes / 2);
+	const pathCharacterCount = Math.floor(pathLengthBytes / 2);
 	// Allocate a buffer to store the path of the process
 	const processFileNameBuffer = Buffer.alloc(pathLengthBytes);
 	// Create a buffer containing the allocated size for the path, as a buffer as it must be writable
-	const processFileNameSizeBuffer = ref.alloc('uint32', pathLengthChars);
+	const processFileNameSizeBuffer = ref.alloc('uint32', pathCharacterCount);
 	// Write process file path to buffer
 	kernel32.QueryFullProcessImageNameW(processHandle, 0, processFileNameBuffer, processFileNameSizeBuffer);
 	// Remove null characters from buffer

--- a/lib/windows.js
+++ b/lib/windows.js
@@ -14,6 +14,8 @@ const Rect = struct({
 	bottom: 'long'
 });
 const RectPointer = ref.refType(Rect);
+const VoidPtr = ref.refType(ref.types.void);
+
 
 // Required by QueryFullProcessImageName
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms684880(v=vs.85).aspx
@@ -31,7 +33,10 @@ const user32 = new ffi.Library('User32.dll', {
 	GetWindowThreadProcessId: ['uint32', ['pointer', 'uint32 *']],
 	// Get window bounds function
 	// https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-getwindowrect
-	GetWindowRect: ['bool', ['pointer', RectPointer]]
+	GetWindowRect: ['bool', ['pointer', RectPointer]],
+	// Iterate through children windows
+	//https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enumchildwindows
+	EnumChildWindows: ['bool', ['pointer', VoidPtr, 'int32']],
 });
 
 const SIZE_T = 'uint64';
@@ -164,10 +169,10 @@ function windows() {
 		user32.EnumChildWindows(activeWindowHandle, windowProc, 0);
 	}
 
-	if (newProcessName!==null && newProcessName !== processName) {
+	if (newProcessName !== null && newProcessName !== processName) {
 		processName = newProcessName;
 	}
-	
+
 
 	// Get process memory counters
 	const memoryCounters = new ProcessMemoryCounters();

--- a/lib/windows.js
+++ b/lib/windows.js
@@ -121,7 +121,53 @@ function windows() {
 	// Get process file path as a string
 	const processPath = wchar.toString(processFileNameBufferClean);
 	// Get process file name from path
-	const processName = path.basename(processPath);
+	let processName = path.basename(processPath);
+	let newProcessName = null;
+
+	// ApplicationFrameHost & Universal Windows Platform Support
+	if (processName === 'ApplicationFrameHost.exe') {
+		const windowProc = ffi.Callback('bool', ['pointer', 'int32'], function (hwnd, lParam) {
+			// Allocate a buffer to store the process ID
+			const processIdBufferChild = ref.alloc('uint32');
+			// Write the process ID creating the window to the buffer (it returns the thread ID, but it's not used here)
+			user32.GetWindowThreadProcessId(hwnd, processIdBufferChild);
+			// Get the process ID as a number from the buffer
+			const processIdChild = ref.get(processIdBufferChild);
+			// Get a "handle" of the process
+			const processHandleChild = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, processIdChild);
+			if (ref.isNull(processHandleChild)) {
+				return undefined; // Failed to get process handle
+			}
+
+			// Set the path length to more than the Windows extended-length MAX_PATH length
+			const pathLengthBytesChild = 66000;
+			// Path length in "characters"
+			const pathLengthCharsChild = Math.floor(pathLengthBytesChild / 2);
+			// Allocate a buffer to store the path of the process
+			const processFileNameBufferChild = Buffer.alloc(pathLengthBytesChild);
+			// Create a buffer containing the allocated size for the path, as a buffer as it must be writable
+			const processFileNameSizeBufferChild = ref.alloc('uint32', pathLengthCharsChild);
+			// Write process file path to buffer
+			kernel32.QueryFullProcessImageNameW(processHandleChild, 0, processFileNameBufferChild, processFileNameSizeBufferChild);
+			// Remove null characters from buffer
+			const processFileNameBufferCleanChild = ref.reinterpretUntilZeros(processFileNameBufferChild, wchar.size);
+			// Get process file path as a string
+			const processPathChild = wchar.toString(processFileNameBufferCleanChild);
+			// Get process file name from path
+			const processNameChild = path.basename(processPathChild);
+
+			if (processNameChild !== processName) {
+				newProcessName = processNameChild;
+			}
+			return true;
+		});
+		user32.EnumChildWindows(activeWindowHandle, windowProc, 0);
+	}
+
+	if (newProcessName!==null && newProcessName !== processName) {
+		processName = newProcessName;
+	}
+	
 
 	// Get process memory counters
 	const memoryCounters = new ProcessMemoryCounters();

--- a/lib/windows.js
+++ b/lib/windows.js
@@ -74,7 +74,7 @@ const kernel32 = new ffi.Library('kernel32', {
 });
 
 //Check parent window for SubWindows and find the unique process inside of it.
-function getSubWindowRealProceessPath(activeWindowHandle, processPath) {
+function getSubWindowRealProcessPath(activeWindowHandle, processPath) {
 
 	let newProcessPath;
 
@@ -181,7 +181,7 @@ function windows() {
 
 	// ApplicationFrameHost & Universal Windows Platform Support
 	if (processName === 'ApplicationFrameHost.exe') {
-		processPath = getSubWindowRealProceessPath(activeWindowHandle, processPath);
+		processPath = getSubWindowRealProcessPath(activeWindowHandle, processPath);
 		processName = path.basename(processPath);
 	}
 

--- a/lib/windows.js
+++ b/lib/windows.js
@@ -124,10 +124,11 @@ function windows() {
 	// Remove null characters from buffer
 	const processFileNameBufferClean = ref.reinterpretUntilZeros(processFileNameBuffer, wchar.size);
 	// Get process file path as a string
-	const processPath = wchar.toString(processFileNameBufferClean);
+	let processPath = wchar.toString(processFileNameBufferClean);
 	// Get process file name from path
 	let processName = path.basename(processPath);
 	let newProcessName = null;
+	let newProcessPath = null;
 
 	// ApplicationFrameHost & Universal Windows Platform Support
 	if (processName === 'ApplicationFrameHost.exe') {
@@ -163,6 +164,7 @@ function windows() {
 
 			if (processNameChild !== processName) {
 				newProcessName = processNameChild;
+				newProcessPath = processPathChild;
 			}
 			return true;
 		});
@@ -171,6 +173,7 @@ function windows() {
 
 	if (newProcessName !== null && newProcessName !== processName) {
 		processName = newProcessName;
+		processPath = newProcessPath;
 	}
 
 
@@ -197,6 +200,7 @@ function windows() {
 	return {
 		platform: 'windows',
 		title: windowTitle,
+		processPath,
 		id: windowId,
 		owner: {
 			name: processName,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "active-win",
-	"version": "6.0.0",
+	"version": "6.1.0",
 	"description": "Get metadata about the active window (title, id, bounds, owner, URL, etc). Works on macOS, Linux, Windows.",
 	"license": "MIT",
 	"repository": "sindresorhus/active-win",


### PR DESCRIPTION
Needed the root of the UWP Applications and continually got "ApplicationFrameHost.exe". 

Introduced code to iterate through children windows of the ApplicationFrameHost.exe which will find the underlying application, and update the processname.