### PR TITLE
Report just active app info if there is no active window on MacOS

### DIFF
--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -83,5 +83,24 @@ for window in windows {
 	exit(0)
 }
 
-print("null")
+// if no acive window lets report just the frontmost app
+let app = NSRunningApplication(processIdentifier: frontmostAppPID)!
+let dict: [String: Any] = [
+	"title": "",
+	"id": 0,
+	"bounds": [
+		"x": 0,
+		"y": 0,
+		"width": 0,
+		"height": 0
+	],
+	"owner": [
+		"name":  app.localizedName!,
+		"processId": frontmostAppPID,
+		"bundleId": app.bundleIdentifier!,
+		"path": app.bundleURL!.path
+	],
+	"memoryUsage": "0"
+]
+print(try! toJson(dict))
 exit(0)


### PR DESCRIPTION
Use case:
 1. on mac start in terminal: `while true; do echo =============; active-win; sleep 5; done`
 2. launch preferences app
 3. minimize preferences app

result:
 Terminal is active app, but there is no active window
 active-win reports:
```
child_process.js:632
    throw err;
    ^

Error: Command failed: /Users/****/.nvm/versions/node/v14.0.0/lib/node_modules/active-win-cli/node_modules/active-win/main
    at checkExecSyncError (child_process.js:611:11)
    at Object.execFileSync (child_process.js:629:15)
    at Function.module.exports.sync (/Users/****/.nvm/versions/node/v14.0.0/lib/node_modules/active-win-cli/node_modules/active-win/index.js:76:32)
    at Object.<anonymous> (/Users/****/.nvm/versions/node/v14.0.0/lib/node_modules/active-win-cli/cli.js:22:23)
    at Module._compile (internal/modules/cjs/loader.js:1185:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1205:10)
    at Module.load (internal/modules/cjs/loader.js:1034:32)
    at Function.Module._load (internal/modules/cjs/loader.js:923:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
    at internal/main/run_main_module.js:17:47 {
  status: 1,
  signal: null,
  output: [ null, '', '' ],
  pid: 5267,
  stdout: '',
  stderr: ''
}
```
after the fix active-win reports:
```
{"memoryUsage":"0","title":"","bounds":{"height":0,"y":0,"x":0,"width":0},"owner":{"name":"System Preferences","path":"\/System\/Applications\/System Preferences.app","processId":4759,"bundleId":"com.apple.systempreferences"},"id":0}
```