### PR TITLE
Add `screenRecordingPermission` option

### DIFF
--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -11,7 +11,7 @@ func getActiveBrowserTabURLAppleScriptCommand(_ appName: String) -> String? {
 	}
 }
 
-let disableScreenRecordingPermission = CommandLine.arguments.contains("--disable-screen-recording-permission")
+let disableScreenRecordingPermission = CommandLine.arguments.contains("--no-screen-recording-permission")
 
 // Show accessibility permission prompt if needed. Required to get the complete window title.
 if !AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,13 @@
 declare namespace activeWin {
 	interface Options {
 		/**
-		Disable the screen recording permission check (macOS)
+		Enable the screen recording permission check (macOS).
 
-		Setting this to true will prevent the Screen Recording permission prompt on macOS versions 10.15 and newer. The `title` property will always be set to an empty string.
-		 */
-		disableScreenRecordingPermission: boolean;
+		Setting this to `false` will prevent the Screen Recording permission prompt on macOS versions 10.15 and newer. The `title` property in the result will always be set to an empty string.
+
+		@default true
+		*/
+		screenRecordingPermission: boolean;
 	}
 
 	interface BaseOwner {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,13 @@
 declare namespace activeWin {
+	interface Options {
+		/**
+		Disable the screen recording permission check (macOS)
+
+		Setting this to true will prevent the Screen Recording permission prompt on macOS versions 10.15 and newer. The `title` property will always be set to an empty string.
+		 */
+		disableScreenRecordingPermission: boolean;
+	}
+
 	interface BaseOwner {
 		/**
 		Name of the app.
@@ -107,7 +116,7 @@ declare const activeWin: {
 	})();
 	```
 	*/
-	(): Promise<activeWin.Result | undefined>;
+	(options?: activeWin.Options): Promise<activeWin.Result | undefined>;
 
 	/**
 	Synchronously get metadata about the [active window](https://en.wikipedia.org/wiki/Active_window) (title, id, bounds, owner, etc).
@@ -132,7 +141,7 @@ declare const activeWin: {
 	}
 	```
 	*/
-	sync(): activeWin.Result | undefined;
+	sync(options?: activeWin.Options): activeWin.Result | undefined;
 };
 
 export = activeWin;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,13 @@
 declare namespace activeWin {
 	interface Options {
 		/**
-		Enable the screen recording permission check (macOS).
+		Enable the screen recording permission check. _(macOS)_
 
-		Setting this to `false` will prevent the Screen Recording permission prompt on macOS versions 10.15 and newer. The `title` property in the result will always be set to an empty string.
+		Setting this to `false` will prevent the screen recording permission prompt on macOS versions 10.15 and newer. The `title` property in the result will always be set to an empty string.
 
 		@default true
 		*/
-		screenRecordingPermission: boolean;
+		readonly screenRecordingPermission: boolean;
 	}
 
 	interface BaseOwner {

--- a/index.js
+++ b/index.js
@@ -1,32 +1,32 @@
 'use strict';
 
-module.exports = () => {
+module.exports = options => {
 	if (process.platform === 'darwin') {
-		return require('./lib/macos')();
+		return require('./lib/macos')(options);
 	}
 
 	if (process.platform === 'linux') {
-		return require('./lib/linux')();
+		return require('./lib/linux')(options);
 	}
 
 	if (process.platform === 'win32') {
-		return require('./lib/windows')();
+		return require('./lib/windows')(options);
 	}
 
 	return Promise.reject(new Error('macOS, Linux, and Windows only'));
 };
 
-module.exports.sync = () => {
+module.exports.sync = options => {
 	if (process.platform === 'darwin') {
-		return require('./lib/macos').sync();
+		return require('./lib/macos').sync(options);
 	}
 
 	if (process.platform === 'linux') {
-		return require('./lib/linux').sync();
+		return require('./lib/linux').sync(options);
 	}
 
 	if (process.platform === 'win32') {
-		return require('./lib/windows').sync();
+		return require('./lib/windows').sync(options);
 	}
 
 	throw new Error('macOS, Linux, and Windows only');

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,7 +4,7 @@ import {Result, LinuxResult, MacOSResult, WindowsResult} from '.';
 
 expectType<Promise<Result | undefined>>(activeWin());
 
-const result = activeWin.sync({ disableScreenRecordingPermission: false });
+const result = activeWin.sync({ screenRecordingPermission: false });
 
 expectType<Result | undefined>(result);
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,7 +4,7 @@ import {Result, LinuxResult, MacOSResult, WindowsResult} from '.';
 
 expectType<Promise<Result | undefined>>(activeWin());
 
-const result = activeWin.sync();
+const result = activeWin.sync({ disableScreenRecordingPermission: false });
 
 expectType<Result | undefined>(result);
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,7 +4,7 @@ import {Result, LinuxResult, MacOSResult, WindowsResult} from '.';
 
 expectType<Promise<Result | undefined>>(activeWin());
 
-const result = activeWin.sync({ screenRecordingPermission: false });
+const result = activeWin.sync({screenRecordingPermission: false});
 
 expectType<Result | undefined>(result);
 

--- a/lib/macos.js
+++ b/lib/macos.js
@@ -19,9 +19,25 @@ const parseMac = stdout => {
 	}
 };
 
-module.exports = async () => {
-	const {stdout} = await execFile(bin);
+const getArguments = options => {
+	if (!options) {
+		return [];
+	}
+
+	const args = [];
+	if (options.disableScreenRecordingPermission === true) {
+		args.push('--disable-screen-recording-permission');
+	}
+
+	return args;
+};
+
+module.exports = async options => {
+	const {stdout} = await execFile(bin, getArguments(options));
 	return parseMac(stdout);
 };
 
-module.exports.sync = () => parseMac(childProcess.execFileSync(bin, {encoding: 'utf8'}));
+module.exports.sync = options => {
+	const stdout = childProcess.execFileSync(bin, getArguments(options), {encoding: 'utf8'});
+	return parseMac(stdout);
+};

--- a/lib/macos.js
+++ b/lib/macos.js
@@ -25,7 +25,7 @@ const getArguments = options => {
 	}
 
 	const args = [];
-	if (options.disableScreenRecordingPermission === true) {
+	if (options.screenRecordingPermission === false) {
 		args.push('--disable-screen-recording-permission');
 	}
 

--- a/lib/macos.js
+++ b/lib/macos.js
@@ -26,7 +26,7 @@ const getArguments = options => {
 
 	const args = [];
 	if (options.screenRecordingPermission === false) {
-		args.push('--disable-screen-recording-permission');
+		args.push('--no-screen-recording-permission');
 	}
 
 	return args;

--- a/readme.md
+++ b/readme.md
@@ -45,19 +45,35 @@ const activeWin = require('active-win');
 
 ## API
 
-### activeWin(options)
+### activeWin(options?)
 
-Accepts an optional dictionary `Options` as only argument and returns a `Promise<Object>` with the result, or `Promise<undefined>` if there is no active window or if the information is not available.
+#### options
 
-### activeWin.sync(options)
+Type: `object`
 
-Accepts an optional dictionary `Options` as only argument and returns an `Object` with the result, or `undefined` if there is no active window.
+##### screenRecordingPermission
 
-## Options
+Type: `boolean`\
+Default: `true`
 
-- `disableScreenRecordingPermission` *(boolean)* - Disable the screen recording permission check (macOS). Setting this to true will prevent the Screen Recording permission prompt on macOS versions 10.15 and newer. The `title` property will always be set to an empty string.
+Enable the screen recording permission check (macOS). Setting this to `false` will prevent the Screen Recording permission prompt on macOS versions 10.15 and newer. The `title` property in the result will always be set to an empty string.
+
+### activeWin.sync(options?)
+
+#### options
+
+Type: `object`
+
+##### screenRecordingPermission
+
+Type: `boolean`\
+Default: `true`
+
+Enable the screen recording permission check (macOS). Setting this to `false` will prevent the Screen Recording permission prompt on macOS versions 10.15 and newer. The `title` property in the result will always be set to an empty string.
 
 ## Result
+
+Returns a `Promise<Object>` with the result, or `Promise<undefined>` if there is no active window or if the information is not available.
 
 - `platform` *(string)* - `'macos'` | `'linux'` | `'windows'`
 - `title` *(string)* - Window title

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ $ npm install active-win
 const activeWin = require('active-win');
 
 (async () => {
-	console.log(await activeWin());
+	console.log(await activeWin(options));
 	/*
 	{
 		title: 'Unicorns - Google Search',
@@ -45,13 +45,17 @@ const activeWin = require('active-win');
 
 ## API
 
-### activeWin()
+### activeWin(options)
 
-Returns a `Promise<Object>` with the result, or `Promise<undefined>` if there is no active window or if the information is not available.
+Accepts an optional dictionary `Options` as only argument and returns a `Promise<Object>` with the result, or `Promise<undefined>` if there is no active window or if the information is not available.
 
-### activeWin.sync()
+### activeWin.sync(options)
 
-Returns an `Object` with the result, or `undefined` if there is no active window.
+Accepts an optional dictionary `Options` as only argument and returns an `Object` with the result, or `undefined` if there is no active window.
+
+## Options
+
+- `disableScreenRecordingPermission` *(boolean)* - Disable the screen recording permission check (macOS). Setting this to true will prevent the Screen Recording permission prompt on macOS versions 10.15 and newer. The `title` property will always be set to an empty string.
 
 ## Result
 

--- a/readme.md
+++ b/readme.md
@@ -51,29 +51,18 @@ const activeWin = require('active-win');
 
 Type: `object`
 
-##### screenRecordingPermission
+##### screenRecordingPermission **(macOS only)**
 
 Type: `boolean`\
 Default: `true`
 
-Enable the screen recording permission check (macOS). Setting this to `false` will prevent the Screen Recording permission prompt on macOS versions 10.15 and newer. The `title` property in the result will always be set to an empty string.
+Enable the screen recording permission check. Setting this to `false` will prevent the screen recording permission prompt on macOS versions 10.15 and newer. The `title` property in the result will always be set to an empty string.
 
 ### activeWin.sync(options?)
 
-#### options
-
-Type: `object`
-
-##### screenRecordingPermission
-
-Type: `boolean`\
-Default: `true`
-
-Enable the screen recording permission check (macOS). Setting this to `false` will prevent the Screen Recording permission prompt on macOS versions 10.15 and newer. The `title` property in the result will always be set to an empty string.
-
 ## Result
 
-Returns a `Promise<Object>` with the result, or `Promise<undefined>` if there is no active window or if the information is not available.
+Returns a `Promise<object>` with the result, or `Promise<undefined>` if there is no active window or if the information is not available.
 
 - `platform` *(string)* - `'macos'` | `'linux'` | `'windows'`
 - `title` *(string)* - Window title


### PR DESCRIPTION
### Why

One of the significant drawbacks is the library asking for Screen Recording permissions for macOS versions 10.15 and newer. Even though the library doesn't actually record the screen, it is required to get the title of the active window. For those who do not need the window title, there should be an option to forgo the Screen Recording permission check.

### Changes

- Add a `disableScreenRecordingPermission` option.
- Skip the screen recording permission check if true.
- Return an empty string as the title if true.

### Related

- https://github.com/sindresorhus/active-win/issues/88
- https://github.com/sindresorhus/active-win/pull/67