### PR TITLE
Add support for Ghost Browser and WaveBox for `url` property (macOS)

### DIFF
--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -2,7 +2,7 @@ import AppKit
 
 func getActiveBrowserTabURLAppleScriptCommand(_ appName: String) -> String? {
 	switch appName {
-	case "Google Chrome", "Google Chrome Beta", "Google Chrome Dev", "Google Chrome Canary", "Brave Browser", "Brave Browser Beta", "Brave Browser Nightly", "Microsoft Edge", "Microsoft Edge Beta", "Microsoft Edge Dev", "Microsoft Edge Canary", "Sidekick", "Opera":
+	case "Google Chrome", "Google Chrome Beta", "Google Chrome Dev", "Google Chrome Canary", "Brave Browser", "Brave Browser Beta", "Brave Browser Nightly", "Microsoft Edge", "Microsoft Edge Beta", "Microsoft Edge Dev", "Microsoft Edge Canary", "Ghost Browser", "Wavebox", "Sidekick", "Opera":
 		return "tell app \"\(appName)\" to get the URL of active tab of front window"
 	case "Safari":
 		return "tell app \"Safari\" to get URL of front document"

--- a/index.d.ts
+++ b/index.d.ts
@@ -74,7 +74,7 @@ declare namespace activeWindow {
 		owner: MacOSOwner;
 
 		/**
-		URL of the active browser tab if the active window is Safari, Chrome (includes Beta, Dev, and Canary), Edge (includes Beta, Dev, and Canary), Brave (includes Beta and Nightly), Sidekick, or Opera.
+		URL of the active browser tab if the active window is Safari, Chrome (includes Beta, Dev, and Canary), Edge (includes Beta, Dev, and Canary), Brave (includes Beta and Nightly), Ghost Browser, WaveBox, Sidekick, or Opera.
 		*/
 		url?: string;
 	}

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ Returns a `Promise<object>` with the result, or `Promise<undefined>` if there is
 	- `processId` *(number)* - Process identifier
 	- `bundleId` *(string)* - Bundle identifier *(macOS only)*
 	- `path` *(string)* - Path to the app
-- `url` *(string?)* - URL of the active browser tab if the active window is Safari, Chrome (includes Beta, Dev, and Canary), Edge (includes Beta, Dev, and Canary), Brave (includes Beta and Nightly), Ghost Browser, WaveBox, Sidekick, or Opera *(macOS only)*
+- `url` *(string?)* - URL of the active browser tab if the active window is Safari, Chrome (includes Beta, Dev, and Canary), Edge (includes Beta, Dev, and Canary), Brave (includes Beta and Nightly), Ghost Browser, Wavebox, Sidekick, or Opera *(macOS only)*
 - `memoryUsage` *(number)* - Memory usage by the window owner process
 
 ## OS support

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ Returns a `Promise<object>` with the result, or `Promise<undefined>` if there is
 	- `processId` *(number)* - Process identifier
 	- `bundleId` *(string)* - Bundle identifier *(macOS only)*
 	- `path` *(string)* - Path to the app
-- `url` *(string?)* - URL of the active browser tab if the active window is Safari, Chrome (includes Beta, Dev, and Canary), Edge (includes Beta, Dev, and Canary), Brave (includes Beta and Nightly), Sidekick, or Opera *(macOS only)*
+- `url` *(string?)* - URL of the active browser tab if the active window is Safari, Chrome (includes Beta, Dev, and Canary), Edge (includes Beta, Dev, and Canary), Brave (includes Beta and Nightly), Ghost Browser, WaveBox, Sidekick, or Opera *(macOS only)*
 - `memoryUsage` *(number)* - Memory usage by the window owner process
 
 ## OS support


### PR DESCRIPTION
Adds additional Chromium-based browsers for macOS to retrieve the URL of the active tab.