### PR TITLE
Use app bundle ID to identify macOS browsers

### DIFF
--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -1,11 +1,11 @@
 import AppKit
 
-func getActiveBrowserTabURLAppleScriptCommand(_ appName: String) -> String? {
-	switch appName {
-	case "Google Chrome", "Google Chrome Beta", "Google Chrome Dev", "Google Chrome Canary", "Brave Browser", "Brave Browser Beta", "Brave Browser Nightly", "Microsoft Edge", "Microsoft Edge Beta", "Microsoft Edge Dev", "Microsoft Edge Canary", "Mighty", "Ghost Browser", "Wavebox", "Sidekick", "Opera", "Vivaldi":
-		return "tell app \"\(appName)\" to get the URL of active tab of front window"
-	case "Safari":
-		return "tell app \"Safari\" to get URL of front document"
+func getActiveBrowserTabURLAppleScriptCommand(_ appId: String) -> String? {
+	switch appId {
+	case "com.google.Chrome", "com.google.Chrome.beta", "com.google.Chrome.dev", "com.google.Chrome.canary", "com.brave.Browser", "com.brave.Browser.beta", "com.brave.Browser.nightly", "com.microsoft.edgemac", "com.microsoft.edgemac.Beta", "com.microsoft.edgemac.Dev", "com.microsoft.edgemac.Canary", "com.mighty.app", "com.ghostbrowser.gb1", "com.bookry.wavebox", "com.pushplaylabs.sidekick", "com.operasoftware.Opera", "com.vivaldi.Vivaldi":
+		return "tell app id \"\(appId)\" to get the URL of active tab of front window"
+	case "com.apple.Safari":
+		return "tell app id \"\(appId)\" to get URL of front document"
 	default:
 		return nil
 	}
@@ -86,7 +86,7 @@ for window in windows {
 
 	// Only run the AppleScript if active window is a compatible browser.
 	if
-		let script = getActiveBrowserTabURLAppleScriptCommand(appName),
+		let script = getActiveBrowserTabURLAppleScriptCommand(app.bundleIdentifier ?? ""),
 		let url = runAppleScript(source: script)
 	{
 		output["url"] = url

--- a/Sources/active-win/main.swift
+++ b/Sources/active-win/main.swift
@@ -2,7 +2,7 @@ import AppKit
 
 func getActiveBrowserTabURLAppleScriptCommand(_ appId: String) -> String? {
 	switch appId {
-	case "com.google.Chrome", "com.google.Chrome.beta", "com.google.Chrome.dev", "com.google.Chrome.canary", "com.brave.Browser", "com.brave.Browser.beta", "com.brave.Browser.nightly", "com.microsoft.edgemac", "com.microsoft.edgemac.Beta", "com.microsoft.edgemac.Dev", "com.microsoft.edgemac.Canary", "com.mighty.app", "com.ghostbrowser.gb1", "com.bookry.wavebox", "com.pushplaylabs.sidekick", "com.operasoftware.Opera", "com.vivaldi.Vivaldi":
+	case "com.google.Chrome", "com.google.Chrome.beta", "com.google.Chrome.dev", "com.google.Chrome.canary", "com.brave.Browser", "com.brave.Browser.beta", "com.brave.Browser.nightly", "com.microsoft.edgemac", "com.microsoft.edgemac.Beta", "com.microsoft.edgemac.Dev", "com.microsoft.edgemac.Canary", "com.mighty.app", "com.ghostbrowser.gb1", "com.bookry.wavebox", "com.pushplaylabs.sidekick", "com.operasoftware.Opera",  "com.operasoftware.OperaNext", "com.operasoftware.OperaDeveloper", "com.vivaldi.Vivaldi":
 		return "tell app id \"\(appId)\" to get the URL of active tab of front window"
 	case "com.apple.Safari":
 		return "tell app id \"\(appId)\" to get URL of front document"

--- a/index.d.ts
+++ b/index.d.ts
@@ -74,7 +74,7 @@ declare namespace activeWindow {
 		owner: MacOSOwner;
 
 		/**
-		URL of the active browser tab if the active window is Safari, Chrome (includes Beta, Dev, and Canary), Edge (includes Beta, Dev, and Canary), Brave (includes Beta and Nightly), Mighty, Ghost Browser, WaveBox, Sidekick, Opera, or Vivaldi.
+		URL of the active browser tab if the active window is Safari, Chrome (includes Beta, Dev, and Canary), Edge (includes Beta, Dev, and Canary), Brave (includes Beta and Nightly), Mighty, Ghost Browser, WaveBox, Sidekick, Opera (includes Beta and Developer), or Vivaldi.
 		*/
 		url?: string;
 	}

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ Returns a `Promise<object>` with the result, or `Promise<undefined>` if there is
 	- `processId` *(number)* - Process identifier
 	- `bundleId` *(string)* - Bundle identifier *(macOS only)*
 	- `path` *(string)* - Path to the app
-- `url` *(string?)* - URL of the active browser tab if the active window is Safari, Chrome (includes Beta, Dev, and Canary), Edge (includes Beta, Dev, and Canary), Brave (includes Beta and Nightly), Mighty, Ghost Browser, Wavebox, Sidekick, Opera, or Vivaldi *(macOS only)*
+- `url` *(string?)* - URL of the active browser tab if the active window is Safari, Chrome (includes Beta, Dev, and Canary), Edge (includes Beta, Dev, and Canary), Brave (includes Beta and Nightly), Mighty, Ghost Browser, Wavebox, Sidekick, Opera (includes Beta and Developer), or Vivaldi *(macOS only)*
 - `memoryUsage` *(number)* - Memory usage by the window owner process
 
 ## OS support


### PR DESCRIPTION
We're currently using AppleScript to get the URL from apps by referencing the app name in the script. I've noticed that changing the name of the browser causes this functionality to break. As an example, if I rename 'Google Chrome' to just 'Chrome' on my mac, it'll break active-win's ability to grab the URL from Chrome.

This PR uses the application bundle ids to identify the browsers capable of providing URL. It also adds Opera Beta and Developer since their names conflicted with their production release.

Fixes https://github.com/sindresorhus/active-win/issues/117