### PR TITLE
Fix support for Flatpak apps

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -80,7 +80,7 @@ const getPathByPidSync = pid => {
 	try {
 		return fs.readlinkSync(`/proc/${pid}/exe`);
 	} catch {
-		return null;
+		return;
 	}
 };
 
@@ -103,12 +103,11 @@ module.exports = async () => {
 			boundsStdout,
 			stdout
 		});
-		data.memoryUsage = await getMemoryUsageByPid(data.owner.processId);
-		let path = null;
-		try {
-			path = await getPathByPid(data.owner.processId);
-		} catch {}
-		
+		const [memoryUsage, path] = await Promise.all([
+			getMemoryUsageByPid(data.owner.processId),
+			getPathByPid(data.owner.processId).catch(() => { return})
+		]);
+		data.memoryUsage = memoryUsage;
 		data.owner.path = path;
 		return data;
 	} catch {

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -77,7 +77,11 @@ const getPathByPid = pid => {
 };
 
 const getPathByPidSync = pid => {
-	return fs.readlinkSync(`/proc/${pid}/exe`);
+	try {
+		return fs.readlinkSync(`/proc/${pid}/exe`);
+	} catch {
+		return null;
+	}
 };
 
 module.exports = async () => {
@@ -99,11 +103,11 @@ module.exports = async () => {
 			boundsStdout,
 			stdout
 		});
-		const [memoryUsage, path] = await Promise.all([
-			getMemoryUsageByPid(data.owner.processId),
-			getPathByPid(data.owner.processId)
-		]);
-		data.memoryUsage = memoryUsage;
+		data.memoryUsage = await getMemoryUsageByPid(data.owner.processId);
+		let path = null;
+		try {
+			path = await getPathByPid(data.owner.processId);
+		} catch {}
 		data.owner.path = path;
 		return data;
 	} catch {

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -108,6 +108,7 @@ module.exports = async () => {
 		try {
 			path = await getPathByPid(data.owner.processId);
 		} catch {}
+		
 		data.owner.path = path;
 		return data;
 	} catch {

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -79,9 +79,7 @@ const getPathByPid = pid => {
 const getPathByPidSync = pid => {
 	try {
 		return fs.readlinkSync(`/proc/${pid}/exe`);
-	} catch {
-		return;
-	}
+	} catch {}
 };
 
 module.exports = async () => {
@@ -105,7 +103,7 @@ module.exports = async () => {
 		});
 		const [memoryUsage, path] = await Promise.all([
 			getMemoryUsageByPid(data.owner.processId),
-			getPathByPid(data.owner.processId).catch(() => { return})
+			getPathByPid(data.owner.processId).catch(() => {})
 		]);
 		data.memoryUsage = memoryUsage;
 		data.owner.path = path;


### PR DESCRIPTION
[Someone has reported on my project's issue board](https://github.com/tkainrad/keycombiner/issues/21#issue-931055902) that my application does not support Flatpak applications.

After some investigation, the problem turned out to be relatively simple. [Due to its sandbox](https://docs.flatpak.org/en/latest/sandbox-permissions.html), it is not possible to retrieve the application path for Flatpak applications. 

Currently, _active-win_ will not return any fields for such an application, because it fails with exception in `getPathByPidSync`/`getPathByPid`:

```
internal/fs/utils.js:230
    throw err;
    ^

Error: EACCES: permission denied, readlink '/proc/3/exe'
    at Object.readlinkSync (fs.js:1028:3)
    at getPathByPidSync (<full-path>/active-win/lib/linux.js:80:12)
    at Object.<anonymous> (<full-path>/active-win/lib/linux.js:158:19)
```

My simple solution attempt is to ignore these errors so that the other fields are returned as expected.