### PR TITLE
Fix: crashes on windows

### DIFF
--- a/lib/windows.js
+++ b/lib/windows.js
@@ -4,7 +4,7 @@ const path = require('path');
 const ffi = require('ffi-napi');
 const wchar = require('ref-wchar-napi');
 const ref = require('ref-napi');
-const struct = require('ref-struct-napi');
+const struct = require('ref-struct-di')(ref);
 
 // Create the struct required to save the window bounds
 const Rect = struct({

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 	"optionalDependencies": {
 		"ffi-napi": "^4.0.3",
 		"ref-napi": "^3.0.2",
-		"ref-struct-napi": "^1.1.1",
+		"ref-struct-di": "^1.1.1",
 		"ref-wchar-napi": "^1.0.3"
 	},
 	"ava": {


### PR DESCRIPTION
Fixes #103 

active-win crashes on windows when called more than once. These crashes are due to use of `ref-struct-napi` which is incompatible with `ref-napi`.  Using `ref-struct-di` instead fixes this.

https://github.com/node-ffi-napi/ref-napi#incompatible-packages
> The ref-struct-napi and ref-array-napi packages have names that sound like they are compatible with this module.
> They are not, and your application will experience crashes if you use them together with ref-napi. Use ref-struct-di or ref-array-di instead.