### PR TITLE
Fix TypeScript type for `bundleId`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,7 @@ declare namespace activeWindow {
 		/**
 		Bundle identifier.
 		*/
-		bundleId: number;
+		bundleId: string;
 	}
 
 	interface MacOSResult extends BaseResult {


### PR DESCRIPTION
[According to the docs this field should be a string](https://www.npmjs.com/package/active-win#:~:text=bundleId%20(string)%20%2D%20Bundle%20identifier%20(macOS%20only)).

Here's what I get when running the `activeWindow()` function on MacOS:
```ts
{
    bounds: {
      height: 1055,
      width: 1920,
      x: 0,
      y: 25,
    },
    id: 18890,
    memoryUsage: 1248,
    owner: {
      bundleId: "com.microsoft.VSCode",     // <---- this is a string!
      name: "Code",
      path: "/Applications/Visual Studio Code.app",
      processId: 31111,
    },
    platform: "macos",
    title: "index.ts — myProject",
  }
```

Typescript shows this error when I try to assign this to a `Result` object:
```
(property) activeWindow.MacOSOwner.bundleId: number
Bundle identifier.

Type 'string' is not assignable to type 'number'.ts(2322)
```