### PR TITLE
fix: Correctly pass activeWindowId into parseLinux

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -90,7 +90,7 @@ async function getWindowInformation(windowId) {
 	]);
 
 	const data = parseLinux({
-		windowId,
+		activeWindowId: windowId,
 		boundsStdout,
 		stdout
 	});
@@ -108,7 +108,7 @@ function getWindowInformationSync(windowId) {
 	const boundsStdout = childProcess.execFileSync(xwininfoBin, [...xpropDetailsArgs, windowId], {encoding: 'utf8'});
 
 	const data = parseLinux({
-		windowId,
+		activeWindowId: windowId,
 		boundsStdout,
 		stdout
 	});


### PR DESCRIPTION
Noticed while running this on Linux that sometimes `WM_CLIENT_LEADER(WINDOW)` is missing from `xprop` output. The code seems to take this into account with: https://github.com/sindresorhus/active-win/blob/27221e5da0a64025bdec8759605694ea84ff9f68/lib/linux.js#L38-L39

However, the named parameter `activeWindowId` is not set correctly by the caller.

This fixes the issue.
