### PR TITLE
feat: add `accessibilityPermission` option

### DIFF
--- a/Sources/ActiveWinCLI/main.swift
+++ b/Sources/ActiveWinCLI/main.swift
@@ -71,13 +71,14 @@ func getWindowInformation(window: [String: Any], windowOwnerPID: pid_t) -> [Stri
 		"memoryUsage": window[kCGWindowMemoryUsage as String] as? Int ?? 0
 	]
 
-	// Only run the AppleScript if active window is a compatible browser.
-	if
-		let bundleIdentifier = app.bundleIdentifier,
-		let script = getActiveBrowserTabURLAppleScriptCommand(bundleIdentifier),
-		let url = runAppleScript(source: script)
-	{
-		output["url"] = url
+	// Run the AppleScript to get the URL if active window is a compatible browser and accessibility permissions are enabled.
+	if !disableAccessibilityPermission {
+		if let bundleIdentifier = app.bundleIdentifier,
+			let script = getActiveBrowserTabURLAppleScriptCommand(bundleIdentifier),
+			let url = runAppleScript(source: script)
+		{
+			output["url"] = url
+		}
 	}
 
 	return output

--- a/Sources/ActiveWinCLI/main.swift
+++ b/Sources/ActiveWinCLI/main.swift
@@ -71,14 +71,14 @@ func getWindowInformation(window: [String: Any], windowOwnerPID: pid_t) -> [Stri
 		"memoryUsage": window[kCGWindowMemoryUsage as String] as? Int ?? 0
 	]
 
-	// Run the AppleScript to get the URL if active window is a compatible browser and accessibility permissions are enabled.
-	if !disableAccessibilityPermission {
-		if let bundleIdentifier = app.bundleIdentifier,
-			let script = getActiveBrowserTabURLAppleScriptCommand(bundleIdentifier),
-			let url = runAppleScript(source: script)
-		{
-			output["url"] = url
-		}
+	// Run the AppleScript to get the URL if the active window is a compatible browser and accessibility permissions are enabled.
+	if
+		!disableAccessibilityPermission,
+		let bundleIdentifier = app.bundleIdentifier,
+		let script = getActiveBrowserTabURLAppleScriptCommand(bundleIdentifier),
+		let url = runAppleScript(source: script)
+	{
+		output["url"] = url
 	}
 
 	return output
@@ -89,13 +89,19 @@ let disableScreenRecordingPermission = CommandLine.arguments.contains("--no-scre
 let enableOpenWindowsList = CommandLine.arguments.contains("--open-windows-list")
 
 // Show accessibility permission prompt if needed. Required to get the URL of the active tab in browsers.
-if !disableAccessibilityPermission && !AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary) {
+if
+	!disableAccessibilityPermission,
+	!AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary)
+{
 	print("active-win requires the accessibility permission in “System Settings › Privacy & Security › Accessibility”.")
 	exit(1)
 }
 
 // Show screen recording permission prompt if needed. Required to get the complete window title.
-if !disableScreenRecordingPermission && !hasScreenRecordingPermission() {
+if
+	!disableScreenRecordingPermission,
+	!hasScreenRecordingPermission()
+{
 	print("active-win requires the screen recording permission in “System Settings › Privacy & Security › Screen Recording”.")
 	exit(1)
 }

--- a/Sources/ActiveWinCLI/main.swift
+++ b/Sources/ActiveWinCLI/main.swift
@@ -88,7 +88,7 @@ let disableAccessibilityPermission = CommandLine.arguments.contains("--no-access
 let disableScreenRecordingPermission = CommandLine.arguments.contains("--no-screen-recording-permission")
 let enableOpenWindowsList = CommandLine.arguments.contains("--open-windows-list")
 
-// Show accessibility permission prompt if needed. Required to get the complete window title.
+// Show accessibility permission prompt if needed. Required to get the URL of the active tab in browsers.
 if !disableAccessibilityPermission && !AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary) {
 	print("active-win requires the accessibility permission in “System Settings › Privacy & Security › Accessibility”.")
 	exit(1)

--- a/Sources/ActiveWinCLI/main.swift
+++ b/Sources/ActiveWinCLI/main.swift
@@ -83,11 +83,12 @@ func getWindowInformation(window: [String: Any], windowOwnerPID: pid_t) -> [Stri
 	return output
 }
 
+let disableAccessibilityPermission = CommandLine.arguments.contains("--no-accessibility-permission")
 let disableScreenRecordingPermission = CommandLine.arguments.contains("--no-screen-recording-permission")
 let enableOpenWindowsList = CommandLine.arguments.contains("--open-windows-list")
 
 // Show accessibility permission prompt if needed. Required to get the complete window title.
-if !AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary) {
+if !disableAccessibilityPermission && !AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary) {
 	print("active-win requires the accessibility permission in “System Settings › Privacy & Security › Accessibility”.")
 	exit(1)
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ declare namespace activeWindow {
 		/**
 		Enable the accessibility permission check. _(macOS)_
 
-		Setting this to `false` will prevent the accessibility permission prompt on macOS versions 10.15 and newer.
+		Setting this to `false` will prevent the accessibility permission prompt on macOS versions 10.15 and newer. The `url` property won't be retrieved.
 
 		@default true
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,15 @@
 declare namespace activeWindow {
 	interface Options {
 		/**
+		Enable the accessibility permission check. _(macOS)_
+
+		Setting this to `false` will prevent the accessibility permission prompt on macOS versions 10.15 and newer.
+
+		@default true
+		*/
+		readonly accessibilityPermission: boolean;
+
+		/**
 		Enable the screen recording permission check. _(macOS)_
 
 		Setting this to `false` will prevent the screen recording permission prompt on macOS versions 10.15 and newer. The `title` property in the result will always be set to an empty string.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -5,7 +5,7 @@ import {Result, LinuxResult, MacOSResult, WindowsResult, BaseOwner} from './inde
 expectType<Promise<Result | undefined>>(activeWindow());
 
 const result = activeWindow.sync({
-	screenRecordingPermission: false, 
+	screenRecordingPermission: false,
 	accessibilityPermission: false
 });
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,7 +4,10 @@ import {Result, LinuxResult, MacOSResult, WindowsResult, BaseOwner} from './inde
 
 expectType<Promise<Result | undefined>>(activeWindow());
 
-const result = activeWindow.sync({screenRecordingPermission: false});
+const result = activeWindow.sync({
+	screenRecordingPermission: false, 
+	accessibilityPermission: false
+});
 
 expectType<Result | undefined>(result);
 

--- a/lib/macos.js
+++ b/lib/macos.js
@@ -21,6 +21,10 @@ const getArguments = options => {
 	}
 
 	const args = [];
+	if (options.accessibilityPermission === false) {
+		args.push('--no-accessibility-permission');
+	}
+
 	if (options.screenRecordingPermission === false) {
 		args.push('--no-screen-recording-permission');
 	}

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,13 @@ Get metadata about the active window.
 
 Type: `object`
 
+##### accessibilityPermission **(macOS only)**
+
+Type: `boolean`\
+Default: `true`
+
+Enable the accessibility permission check. Setting this to `false` will prevent the accessibility permission prompt on macOS versions 10.15 and newer.
+
 ##### screenRecordingPermission **(macOS only)**
 
 Type: `boolean`\

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ Type: `object`
 Type: `boolean`\
 Default: `true`
 
-Enable the accessibility permission check. Setting this to `false` will prevent the accessibility permission prompt on macOS versions 10.15 and newer.
+Enable the accessibility permission check. Setting this to `false` will prevent the accessibility permission prompt on macOS versions 10.15 and newer. The `url` property won't be retrieved.
 
 ##### screenRecordingPermission **(macOS only)**
 


### PR DESCRIPTION
### Why

There has been issues with macOS users regarding accessibility permission. The accessibility permission is needed in order to get the complete window title. Apparently, the `screenRecordingPermission` already handles this concern so there is no need for the accessibility permission. To fix this we could just update the `if` condition but just in case, this PR just adds a new option `accessibilityPermission`.

- `accessibilityPermission: false` - disables the accessibility permission prompt.

### Changes

- Add a `accessibilityPermission` option.
- Skip the accessibility permission check if true.

### Related

- #88 
- #67 
- #96 