### PR TITLE
fix: remove accessibility prompt 🐛

### DIFF
--- a/Sources/ActiveWinCLI/main.swift
+++ b/Sources/ActiveWinCLI/main.swift
@@ -86,12 +86,6 @@ func getWindowInformation(window: [String: Any], windowOwnerPID: pid_t) -> [Stri
 let disableScreenRecordingPermission = CommandLine.arguments.contains("--no-screen-recording-permission")
 let enableOpenWindowsList = CommandLine.arguments.contains("--open-windows-list")
 
-// Show accessibility permission prompt if needed. Required to get the complete window title.
-if !AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary) {
-	print("active-win requires the accessibility permission in “System Settings › Privacy & Security › Accessibility”.")
-	exit(1)
-}
-
 // Show screen recording permission prompt if needed. Required to get the complete window title.
 if !disableScreenRecordingPermission && !hasScreenRecordingPermission() {
 	print("active-win requires the screen recording permission in “System Settings › Privacy & Security › Screen Recording”.")


### PR DESCRIPTION
### Why

There has been issues with macOS users regarding accessibility permission. The accessibility permission is needed in order to get the complete window title. Apparently, the `screenRecordingPermission` already handles this concern so there is no need for the accessibility permission. To fix this we just completely remove the code for the accessibility prompt check.

### Changes

- Removed accessibility prompt check

### Related

- Fixes #88 
- #67 
- #96 
- #177 