### PR TITLE
chore: remove accessibility permission check and option

### DIFF
--- a/Sources/ActiveWinCLI/main.swift
+++ b/Sources/ActiveWinCLI/main.swift
@@ -71,9 +71,8 @@ func getWindowInformation(window: [String: Any], windowOwnerPID: pid_t) -> [Stri
 		"memoryUsage": window[kCGWindowMemoryUsage as String] as? Int ?? 0
 	]
 
-	// Run the AppleScript to get the URL if the active window is a compatible browser and accessibility permissions are enabled.
+	// Only run the AppleScript if active window is a compatible browser.
 	if
-		!disableAccessibilityPermission,
 		let bundleIdentifier = app.bundleIdentifier,
 		let script = getActiveBrowserTabURLAppleScriptCommand(bundleIdentifier),
 		let url = runAppleScript(source: script)
@@ -84,18 +83,8 @@ func getWindowInformation(window: [String: Any], windowOwnerPID: pid_t) -> [Stri
 	return output
 }
 
-let disableAccessibilityPermission = CommandLine.arguments.contains("--no-accessibility-permission")
 let disableScreenRecordingPermission = CommandLine.arguments.contains("--no-screen-recording-permission")
 let enableOpenWindowsList = CommandLine.arguments.contains("--open-windows-list")
-
-// Show accessibility permission prompt if needed. Required to get the URL of the active tab in browsers.
-if
-	!disableAccessibilityPermission,
-	!AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary)
-{
-	print("active-win requires the accessibility permission in “System Settings › Privacy & Security › Accessibility”.")
-	exit(1)
-}
 
 // Show screen recording permission prompt if needed. Required to get the complete window title.
 if

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,6 @@
 declare namespace activeWindow {
 	interface Options {
 		/**
-		Enable the accessibility permission check. _(macOS)_
-
-		Setting this to `false` will prevent the accessibility permission prompt on macOS versions 10.15 and newer. The `url` property won't be retrieved.
-
-		@default true
-		*/
-		readonly accessibilityPermission: boolean;
-
-		/**
 		Enable the screen recording permission check. _(macOS)_
 
 		Setting this to `false` will prevent the screen recording permission prompt on macOS versions 10.15 and newer. The `title` property in the result will always be set to an empty string.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,10 +4,7 @@ import {Result, LinuxResult, MacOSResult, WindowsResult, BaseOwner} from './inde
 
 expectType<Promise<Result | undefined>>(activeWindow());
 
-const result = activeWindow.sync({
-	screenRecordingPermission: false,
-	accessibilityPermission: false
-});
+const result = activeWindow.sync({screenRecordingPermission: false});
 
 expectType<Result | undefined>(result);
 

--- a/lib/macos.js
+++ b/lib/macos.js
@@ -21,9 +21,6 @@ const getArguments = options => {
 	}
 
 	const args = [];
-	if (options.accessibilityPermission === false) {
-		args.push('--no-accessibility-permission');
-	}
 
 	if (options.screenRecordingPermission === false) {
 		args.push('--no-screen-recording-permission');

--- a/readme.md
+++ b/readme.md
@@ -50,13 +50,6 @@ Get metadata about the active window.
 
 Type: `object`
 
-##### accessibilityPermission **(macOS only)**
-
-Type: `boolean`\
-Default: `true`
-
-Enable the accessibility permission check. Setting this to `false` will prevent the accessibility permission prompt on macOS versions 10.15 and newer. The `url` property won't be retrieved.
-
 ##### screenRecordingPermission **(macOS only)**
 
 Type: `boolean`\


### PR DESCRIPTION
### Description

The accessibility permission is no longer needed to get the `url` of the active browser tab. As a result, the `accessibilityPermission` option and the associated checks for process/application trust have been removed from the codebase.

### Changes

- The `accessibilityPermission` configuration option has been completely removed.
- The check to verify if the process/application is trusted for accessibility access has been excised.

### Demo

https://github.com/sindresorhus/active-win/assets/153492344/0547a253-eeb3-49a6-b859-314892edb96a


### Related

- #88 
- #177 