### PR TITLE
chore: fix accessibility permission check logic 🔧

### DIFF
--- a/Sources/ActiveWinCLI/main.swift
+++ b/Sources/ActiveWinCLI/main.swift
@@ -89,12 +89,11 @@ let disableScreenRecordingPermission = CommandLine.arguments.contains("--no-scre
 let enableOpenWindowsList = CommandLine.arguments.contains("--open-windows-list")
 
 // Show accessibility permission prompt if needed. Required to get the URL of the active tab in browsers.
-if
-	!disableAccessibilityPermission,
-	!AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary)
-{
-	print("active-win requires the accessibility permission in “System Settings › Privacy & Security › Accessibility”.")
-	exit(1)
+if !disableAccessibilityPermission {
+	if !AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary) {
+		print("active-win requires the accessibility permission in “System Settings › Privacy & Security › Accessibility”.")
+		exit(1)
+	}
 }
 
 // Show screen recording permission prompt if needed. Required to get the complete window title.


### PR DESCRIPTION
### Description

This pull request addresses an issue where the package was incorrectly prompting for accessibility permissions even when the `disableAccessibilityPermission` option was set to `false`.

### Changes

- Updated the logic in `main.swift` to ensure that the accessibility permission prompt is conditionally executed based on the `disableAccessibilityPermission` flag.
- Wrapped the `AXIsProcessTrustedWithOptions` call within an explicit if block to prevent unintended permission prompts.

### Problem

The original code used a comma-separated list of conditions in an if statement, which in Swift, functions as a logical AND operator. This meant that both conditions had to be evaluated, and as long as the first condition `(!disableAccessibilityPermission)` was `true` (i.e., `disableAccessibilityPermission` was `false`), the second condition `(!AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary))` would also be evaluated. 

This led to a situation where, even when `disableAccessibilityPermission` was set to false, the code would still trigger the accessibility permission check because the second condition was always checked, thus resulting in an unintended prompt for accessibility permission.

### Solution

The solution involved restructuring the conditional statement to ensure that the `AXIsProcessTrustedWithOptions` check is only performed when `disableAccessibilityPermission` is explicitly set to false. Now, the second condition is entirely dependent on the first condition being true. This change respects the user's preference for the `disableAccessibilityPermission` flag and prevents the accessibility permission prompt from appearing unless it is necessary.

### Testing

- [x] Made sure VSCode and terminal did not have accessibility or screen recording permissions
- [x] Tested changes with `npm test` on `active-win` project
- [x] Tested on my electron app in `dev` environment
- [x] Tested on my electron app in `production` environment

### Disclaimer

Please note that while I am not a Swift developer by profession, I have taken care to ensure that the changes proposed in this pull request adhere to best practices to the best of my knowledge and have been thoroughly tested.