### PR TITLE
fix(linux): handle individual window errors in openWindows

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -157,13 +157,29 @@ export async function openWindows() {
 		}
 
 		const openWindows = [];
+		const failedWindows = [];
 
 		for await (const windowId of windowsIds) {
-			openWindows.push(await getWindowInformation(Number.parseInt(windowId, 16)));
+			try {
+				openWindows.push(await getWindowInformation(Number.parseInt(windowId, 16)));
+			} catch (error) {
+				failedWindows.push(windowId);
+				if (process.env.DEBUG_GET_WINDOWS) {
+					console.debug(`[get-windows] Failed to get information for window ${windowId}:`, error.message);
+				}
+			}
 		}
 
-		return openWindows;
-	} catch {
+		if (failedWindows.length > 0 && process.env.DEBUG_GET_WINDOWS) {
+			console.debug(`[get-windows] Successfully retrieved ${openWindows.length} windows, failed for ${failedWindows.length} windows`);
+		}
+
+		return openWindows.length > 0 ? openWindows : undefined;
+	} catch (error) {
+		if (process.env.DEBUG_GET_WINDOWS) {
+			console.debug('[get-windows] Failed to execute xprop:', error.message);
+		}
+
 		return undefined;
 	}
 }
@@ -178,15 +194,30 @@ export function openWindowsSync() {
 		}
 
 		const openWindows = [];
+		const failedWindows = [];
 
 		for (const windowId of windowsIds) {
-			const windowInformation = getWindowInformationSync(Number.parseInt(windowId, 16));
-			openWindows.push(windowInformation);
+			try {
+				const windowInformation = getWindowInformationSync(Number.parseInt(windowId, 16));
+				openWindows.push(windowInformation);
+			} catch (error) {
+				failedWindows.push(windowId);
+				if (process.env.DEBUG_GET_WINDOWS) {
+					console.debug(`[get-windows] Failed to get information for window ${windowId}:`, error.message);
+				}
+			}
 		}
 
-		return openWindows;
+		if (failedWindows.length > 0 && process.env.DEBUG_GET_WINDOWS) {
+			console.debug(`[get-windows] Successfully retrieved ${openWindows.length} windows, failed for ${failedWindows.length} windows`);
+		}
+
+		return openWindows.length > 0 ? openWindows : undefined;
 	} catch (error) {
-		console.log(error);
+		if (process.env.DEBUG_GET_WINDOWS) {
+			console.debug('[get-windows] Failed to execute xprop:', error.message);
+		}
+
 		return undefined;
 	}
 }


### PR DESCRIPTION
## Problem

The `openWindows()` function on Linux returns `undefined` when any single window fails to retrieve information. This causes a complete loss of window tracking functionality even when most windows are accessible.

## Root Cause

The issue occurs in `lib/linux.js` at line 162 where the `for await` loop doesn't handle errors for individual windows. When `getWindowInformation()` throws an error for any window (common with zombie windows or permission issues), the entire function fails.

## Solution

This PR adds try-catch blocks around individual `getWindowInformation()` calls, allowing the function to:
- Continue processing other windows when one fails
- Return a list of accessible windows
- Only return `undefined` when no windows can be accessed

## Changes

- ✅ Added error handling for individual windows in `openWindows()`
- ✅ Added error handling for individual windows in `openWindowsSync()`
- ✅ Added optional debug logging via `DEBUG_GET_WINDOWS` environment variable
- ✅ Maintains backward compatibility

## Testing

- Tested on Ubuntu 22.04 with X11
- Verified behavior with zombie windows (processes terminated but window IDs remain)
- Confirmed that valid windows are returned when some windows fail
- No performance impact for normal operation

Test output showing the fix working:
```
Testing openWindows fix...
[get-windows] Failed to get information for window  0x6e00004: Unterminated string in JSON at position 32
[get-windows] Failed to get information for window  0xac00004: Cannot read properties of undefined
[get-windows] Successfully retrieved 17 windows, failed for 2 windows
Found 17 windows
Active window: Claude Code - get-windows - Cursor
✅ Fix working: openWindows returned valid list
```

## Breaking Changes

None. The function signature and return behavior remain the same for normal operation.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Tests pass locally
- [x] Backward compatibility maintained
- [x] No unnecessary console output in production

This fix aligns the Linux implementation with the Windows C++ implementation, which already handles individual window errors gracefully.

🤖 Generated with [Claude Code](https://claude.ai/code)