### PR TITLE
fix: Improve window filtering logic to include fullscreen applications

### DIFF
--- a/Sources/windows/main.cc
+++ b/Sources/windows/main.cc
@@ -240,9 +240,12 @@ BOOL CALLBACK EnumDekstopWindowsProc(HWND hwnd, LPARAM lParam) {
 		WINDOWINFO winInfo{};
 		GetWindowInfo(hwnd, &winInfo);
 
+		const bool hasCaption = (winInfo.dwStyle & WS_CAPTION) == WS_CAPTION;
+		const bool hasPopup = (winInfo.dwStyle & WS_POPUP) == WS_POPUP;
+
 		if (
 			(winInfo.dwExStyle & WS_EX_TOOLWINDOW) == 0
-			&& (winInfo.dwStyle & WS_CAPTION) == WS_CAPTION
+			&& (hasCaption || hasPopup)
 			&& (winInfo.dwStyle & WS_CHILD) == 0
 		) {
 			int ClockedVal;

--- a/Sources/windows/main.cc
+++ b/Sources/windows/main.cc
@@ -242,10 +242,13 @@ BOOL CALLBACK EnumDekstopWindowsProc(HWND hwnd, LPARAM lParam) {
 
 		const bool hasCaption = (winInfo.dwStyle & WS_CAPTION) == WS_CAPTION;
 		const bool hasPopup = (winInfo.dwStyle & WS_POPUP) == WS_POPUP;
+		const bool isOwnedWindow = GetWindow(hwnd, GW_OWNER) != NULL;
+		const bool isAppWindow = (winInfo.dwExStyle & WS_EX_APPWINDOW) == WS_EX_APPWINDOW;
 
 		if (
 			(winInfo.dwExStyle & WS_EX_TOOLWINDOW) == 0
 			&& (hasCaption || hasPopup)
+			&& (!isOwnedWindow || isAppWindow)
 			&& (winInfo.dwStyle & WS_CHILD) == 0
 		) {
 			int ClockedVal;


### PR DESCRIPTION
Fix for the the issue #161

## Cause
Fullscreen apps often do not have a caption/title bar (`WS_CAPTION`) and are implemented as popup windows (`WS_POPUP`). The old filter dropped these windows from `openWindows()` results even though they are valid top-level visible windows.

## What changed
`openWindows()` now includes fullscreen apps that were previously missing, while preserving existing filters for tool windows and child windows. 

- Updated `EnumDekstopWindowsProc` in main.cc.
- Added style checks:
  - `hasCaption = (dwStyle & WS_CAPTION) == WS_CAPTION`
  - `hasPopup = (dwStyle & WS_POPUP) == WS_POPUP`
- Replaced the strict caption requirement with:
  - `(hasCaption || hasPopup)`